### PR TITLE
Fixed combine() not working when empty ch_fastq

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params {
     groups                     = 'all'
 
     // merqury/meryl options
-    skip_merqury               = false
+    run_merqury                = false
     kvalue                     = 21
 
     // BUSCO options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -312,9 +312,9 @@
           "default": 21,
           "description": "k size for meryl (merqury)"
         },
-        "skip_merqury": {
+        "run_merqury": {
           "type": "boolean",
-          "description": "Skip meryl/merqury step?"
+          "description": "Run meryl/merqury step?"
         },
         "skip_tidk": {
           "type": "boolean",

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -148,6 +148,9 @@ def validateInputParameters() {
 //
 def validateInputSamplesheet(input) {
     def (meta, refseq, fasta, gff, fastq) = input
+    if (params.run_merqury && !fastq) { // Perhaps this should be on validateInputParameters()
+        error("You are runnning using --run_merqury flag but no fastq was found")
+    }
     // As for now, there are only two input options: RefSeq ID or local files. The pipeline will throw an error if the sample sheet does not contain the proper information
     // If --genome_only parameter
     // Check for genome-only mode

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -154,7 +154,7 @@ workflow GENOMEQC {
         | combine(ch_fastq, by:0)
         | multiMap {
             meta, fasta, gff, fq ->
-                fasta : fasta ? tuple( meta, file(fasta) ) : null
+                fasta : fasta ? tuple( meta, file(fasta) ) : null // Not sure if conditional is necessary anymore
                 gff   : gff   ? tuple( meta, file(gff) )   : null
                 fq    : fq    ? tuple( meta, file(fq) )    : null
         }

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -174,7 +174,7 @@ workflow GENOMEQC {
     // Merqury: Evaluate genome assemblies with k-mers and more
     // https://github.com/marbl/merqury
     // Only run if not skipping and fastq is provided in the samplesheet
-    if (!params.skip_merqury && ch_input.fq) {
+    if (params.run_merqury) {
         // MODULE: MERYL_COUNT
         MERYL_COUNT(
             ch_input.fq,

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -3,7 +3,7 @@
     IMPORT MODULES / SUBWORKFLOWS / FUNCTIONS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-include { MERYL_UNIONSUM                         } from '../modules/nf-core/meryl/unionsum/main'
+include { MERYL_UNIONSUM                      } from '../modules/nf-core/meryl/unionsum/main'
 include { MERYL_COUNT                         } from '../modules/nf-core/meryl/count/main'
 include { MERQURY_MERQURY                     } from '../modules/nf-core/merqury/merqury/main'
 include { CREATE_PATH                         } from '../modules/local/create_path'
@@ -138,25 +138,25 @@ workflow GENOMEQC {
     // You have to do this because if you pass in file() in the initial map, 
     // it'll fail if you don't supply a fastq, because you can't pass an empty to file()
 
-    ch_fastq
-        | map{meta, fq -> fq ? [meta, file(fq)] : [meta, fq]}
-        | filter { meta, fq -> fq && fq.name =~ /(\.fastq|\.fq|\.fastq\.gz|\.fq\.gz)$/ }
-        | set {ch_fastq}
+    //ch_fastq
+    //    | map{meta, fq -> fq ? [meta, file(fq)] : [meta, fq]}
+    //    | filter { meta, fq -> fq && fq.name =~ /(\.fastq|\.fq|\.fastq\.gz|\.fq\.gz)$/ }
+    //    | set {ch_fastq}
     
     //
     // Define multi-channel object
     //
 
     // Combine both fasta, gff and fastq channels into a single multi-channel object using multiMap, so that they are in sync all the time
-
+    // If element (fasta, gff, fq) is empty, it will return an empty (null) channel
     ch_fasta
         | combine(ch_gff, by:0) // by:0 | Only combine when both channels share the same id
         | combine(ch_fastq, by:0)
         | multiMap {
-            meta, fasta, gff, fastq ->
-                fasta : tuple( meta, fasta )
-                gff   : tuple( meta, gff )
-                fq    : tuple( meta, fastq )
+            meta, fasta, gff, fq ->
+                fasta : fasta ? tuple( meta, file(fasta) ) : null
+                gff   : gff   ? tuple( meta, file(gff) )   : null
+                fq    : fq    ? tuple( meta, file(fq) )    : null
         }
         | set { ch_input }
 
@@ -174,7 +174,7 @@ workflow GENOMEQC {
     // Merqury: Evaluate genome assemblies with k-mers and more
     // https://github.com/marbl/merqury
     // Only run if not skipping and fastq is provided in the samplesheet
-    if (!params.merqury_skip && ch_input.fq) {
+    if (!params.skip_merqury && ch_input.fq) {
         // MODULE: MERYL_COUNT
         MERYL_COUNT(
             ch_input.fq,


### PR DESCRIPTION
Empty ``ch_fastq`` would result in an empty ``ch_input``. Removed filtering from ``ch_fastq`` channel so that it can be combined with the other channels (``ch_fasta`` and ``ch_gff``)