### PR TITLE
Decreased size of results folder

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -18,15 +18,12 @@ process {
         saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
     ]
 
-    withName: FASTQC {
-        ext.args = '--quiet'
-    }
-
     withName: 'NCBIGENOMEDOWNLOAD' {
         ext.args = "--format fasta,gff -N"
         publishDir = [
             path: { "${params.outdir}/ncbigenomedownload" },
             mode: params.publish_dir_mode,
+            enabled: params.save_assembly,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -36,10 +33,38 @@ process {
         publishDir = [
             path: { "${params.outdir}/gffread" },
             mode: params.publish_dir_mode,
+            enabled: params.save_extracted_seqs,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
+    withName: 'PIGZ_UNCOMPRESS' {
+        publishDir = [
+            path: { "${params.outdir}/agat" },
+            mode: params.publish_dir_mode,
+            enabled: false,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+
+    withName: 'AGAT_SPSTATISTICS' {
+        publishDir = [
+            path: { "${params.outdir}/agat" },
+            mode: params.publish_dir_mode,
+            //pattern: '*.txt'
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: 'AGAT_CONVERTSPGXF2GXF' {
+        publishDir = [
+            path: { "${params.outdir}/agat" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_validated_annotation,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
 
     withName: 'FASTAVALIDATOR' {
         publishDir = [
@@ -53,6 +78,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/orthofinder" },
             mode: params.publish_dir_mode,
+            enabled: params.save_orthofinder_results,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -61,6 +87,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/busco" },
             mode: params.publish_dir_mode,
+            pattern: '*.txt',
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -89,6 +116,12 @@ process {
 
     withName: 'SORT_BY_LENGTH' {
         ext.prefix = { "${meta.id}_sorted" }
+        publishDir = [
+            path: { "${params.outdir}/tidk_explore" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_sorted_seqs,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 
     withName: 'TIDK_EXPLORE' {
@@ -113,6 +146,7 @@ process {
         publishDir = [
             path: { "$params.outdir/output_data/longest" },
             mode: params.publish_dir_mode,
+            enabled: params.save_longest_isoform,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
@@ -120,14 +154,6 @@ process {
     withName: 'PLOT_BUSCO_IDEOGRAM' {
         publishDir = [
             path: { "${params.outdir}/busco_ideogram" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: 'LONGEST' {
-        publishDir = [
-            path: { "${params.outdir}/longest_isoform" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,13 +18,30 @@ params {
     igenomes_base              = null
     igenomes_ignore            = false
 
-    // tidk skip
+    // tidk options
     skip_tidk                  = false
+
+    // seqkit options
+    save_sorted_seqs           = false
+
     // Genome only option
     genome_only                = null
 
+    // AGAT options
+    save_validated_annotation  = false
+
     // ncbigenomedownload options
     groups                     = 'all'
+    save_assembly              = false
+
+    // GFFREAD options
+    save_extracted_seqs        = false
+
+    // orthofinder options
+    save_orthofinder_results   = false
+
+    // Longest options
+    save_longest_isoform       = false
 
     // merqury/meryl options
     run_merqury                = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -292,7 +292,7 @@
         },
         "busco_lineage": {
           "type": "string",
-          "default": "auto",
+          "default": "hymenoptera_odb10",
           "description": "A flag to set the busco lineage. Default: auto"
         },
         "busco_lineages_path": {
@@ -347,5 +347,31 @@
     {
       "$ref": "#/definitions/generic_options"
     }
-  ]
+  ],
+  "properties": {
+    "save_sorted_seqs": {
+      "type": "boolean",
+      "description": "Publish sorted fasta genome files from TIDK Explore subworkflow"
+    },
+    "save_validated_annotation": {
+      "type": "boolean",
+      "description": "Publish gff files validated by AGAT"
+    },
+    "save_assembly": {
+      "type": "boolean",
+      "description": "Publish genomes and/or annotations of user-supplied RefSeq IDs"
+    },
+    "save_extracted_seqs": {
+      "type": "boolean",
+      "description": "Publish extracted protein fasta files by GFFREAD"
+    },
+    "save_orthofinder_results": {
+      "type": "boolean",
+      "description": "Publish orthofinder results"
+    },
+    "save_longest_isoform": {
+      "type": "boolean",
+      "description": "Publish longest protein isoform fasta files"
+    }
+  }
 }


### PR DESCRIPTION
Closes #99.

## Changes

1. Added argument options for the publication of some of the output files. By default, these will not be published (`enabled = false`).
2.  For some modules, only certain output files will be published (e.g. for `BUSCO_BUSCO`, only those with the `'*.txt'` pattern).
3. Output files generated by some modules will not be published at all (e.g. `PIGZ_UNCOMPRESS`).

## Comments

These changes should decrease the size of the results folder significantly.

And I still need to update `nextflow_schema.json`.