### PR TITLE
Change branch logic and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ We thank the following people for their extensive assistance in the development 
 - [Lauren Huet](https://github.com/LaurenHuet) ([Schmidt Ocean Institute](https://schmidtocean.org/))
 - [Stephen Turner](https://github.com/stephenturner/) ([Colossal Biosciences](https://colossal.com/))
 - [Felipe Perez Cobos](https://github.com/fperezcobos) ([Institute of Agrifood Research and Technology](https://www.irta.cat/en/))
+- [Simon Murray](https://github.com/SimonDMurray) ([Nextflow Ambassador](https://www.nextflow.io/our_ambassadors.html))
 
 <!-- TODO nf-core: If applicable, make list of people who have also contributed -->
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ nextflow run nf-core/genomeqc \
 You can run the pipeline using a test profile and docker:
 
 ```bash
-nextflow run nf-core/genomeqc -profile docker --outdir ./results
+nextflow run nf-core/genomeqc -profile test,docker --outdir ./results
 ```
 
 <!-- TODO nf-core: update the following command to include all required parameters for a minimal example -->

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -42,8 +42,8 @@ workflow GENOMEQC {
                     validateInputSamplesheet(it) // Input validation (check local subworkflow)
                 }
                 | branch {
-                    ncbi  : it.size() == 3
-                    local : it.size() == 4
+                    ncbi  : it[1] != null
+                    local : it[1] == null
                 }
 
     // MODULE: Run create_path


### PR DESCRIPTION
I have made the branch operator use the presence or lack of refseq column to branch samples in the pipeline rather than tuple length.

I also fixed the lack of `test` profile in the example test command