### PR TITLE
Run genomeqc on both GTF and GFF

### DIFF
--- a/bin/plot_tree_summary.R
+++ b/bin/plot_tree_summary.R
@@ -74,7 +74,7 @@ tree <- read.tree(args$tree_file)
 
 # Clean tree tip labels
 tree$tip.label <- trimws(tree$tip.label)
-tree$tip.label <- tolower(tree$tip.label)
+#tree$tip.label <- tolower(tree$tip.label)
 
 # If radious of pie charts is to big, it can
 # mess the position of the pies, make them
@@ -85,7 +85,7 @@ if (length(tree$tip.label) < 7) {
 }
 
 # Capitalize first letter of tip labels
-tree$tip.label <- sub("^(\\w)(.*)", "\\U\\1\\L\\2", tree$tip.label, perl = TRUE)
+#tree$tip.label <- sub("^(\\w)(.*)", "\\U\\1\\L\\2", tree$tip.label, perl = TRUE)
 
 # Read the data table from the file, ensuring species column is read as character
 # Load BUSCO

--- a/docs/output.md
+++ b/docs/output.md
@@ -19,10 +19,10 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - Genome quality metrics:
   - [Quast](#quast) - Genome quality and contiguity metrics
   - [tidk](#tidk) - Identify telomeric repeats
-  - [Merqury](#merqury) - Genome completeness and accuracy basedon raw sequecing k-mer counts
+  - [Merqury](#merqury) - Genome completeness and accuracy based on raw sequecing k-mer counts
 - Annotation quality metrics:
-  - [AGAT sp_statistics](#agat-sp_statistics) - Report with gene statistics
-  - [AGAT sp_keep_longest_isoform](#agat-sp_keep_longest_isoform) - Filter longest isoform from GFF file
+  - [AGAT sp_statistics](#agat-sp_statistics) - Gene statistics
+  - [AGAT sp_keep_longest_isoform](#agat-sp_keep_longest_isoform) - Filter longest isoform from GXF file
   - [Gene overlaps](#gene-overlaps) - Find overlapping genes (sense and antisense)
 - [GffRead](#gffread) - Extract longest isoform from FASTA file
 - [BUSCO](#busco) - Genome completeness based on single copy markers
@@ -39,7 +39,7 @@ pigz is used to uncompress `.gz` input files, as some nf-core/genomeqc modules r
 
 [NCBI genome download](https://github.com/kblin/ncbi-genome-download) is a tool for downloading assemlbies from the NCBI FTP site.
 
-In nf-core/genomeqc, it inputs RefSeq IDs and donwloads the respective assembly and annotation in FASTA and GFF formats. If local files are provided, this step is skipped.
+It inputs RefSeq IDs and donwloads the respective assembly and annotation in FASTA and GFF formats. If local files are provided, this step is skipped.
 
 <details markdown="1">
 <summary>Output files</summary>
@@ -116,13 +116,13 @@ To run nf-core/genomeqc with merqury, the flag `--run_merqury` must be provided.
 
 ### AGAT sp_keep_longest_isoform
 
-[AGAT sp_keep_longest_isoform](https://agat.readthedocs.io/en/latest/tools/agat_sp_keep_longest_isoform.html) filters GFF file to keep the longest isoform per gene. Longest isoforms are recommended as input for both BUSCO and Orthofinder.
+[AGAT sp_keep_longest_isoform](https://agat.readthedocs.io/en/latest/tools/agat_sp_keep_longest_isoform.html) filters GXF file to keep the longest isoform per gene. Longest isoforms are recommended as input for both BUSCO and Orthofinder.
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `longest/`
-  - `<species_name>.longest.gff3`: Contig viewr in HTML format
+  - `<species_name>.longest.g*f`: Contig viewr in HTML format
 
 </details>
 
@@ -130,7 +130,7 @@ This directory will only be present if `--save_longest_isoform` flag is set.
 
 ### Gene overlaps
 
-**Gene overlaps** is a local module based on the R package [GenomicRanges](https://bioconductor.org/packages/release/bioc/html/GenomicRanges.html), used for manipulating genomic intervals. It finds the number of genes that are overlapping in the GFF file, which can be used as a metric to evaluate the quality of the annotation.
+**Gene overlaps** is a local module based on the R package [GenomicRanges](https://bioconductor.org/packages/release/bioc/html/GenomicRanges.html), used for manipulating genomic intervals. It finds the number of genes that are overlapping in the GXF file, which can be used as a metric to evaluate the quality of the annotation.
 
 It outputs a brief report with information about the number of reads, the number of genes fully contained in sense direction and in the antisense direction, and the total number of overlapping genes.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,19 +18,21 @@ Before running the pipeline, you will need to create a samplesheet with informat
 
 The content of the samplesheet will depend on the mode you are using to run the pipeline -**genome only** or **genome and annotation**-, the inclusion of FASTQ reads to run **Merqury**, and the origin of the genome assemblies and annotations (**local** or **RefSeq**). Refer to their sections for more information on [running modes](#modes) and [running with **Merqury**](#running-with-merqury). Nonetheless, you must always indicate the species name of each sample using the **species** field.
 
-If running the pipeline on **local** files, point to the location these files using the **fasta** and **gff** fields:
+In **genome and annotation** mode, genome assemblies should be given in FASTA format, whereas feature annotations can be given in GFF or GTF formats (GXF/gxf is used as notation when referring annotation in the documentation).
+
+If running the pipeline on **local** files, point to the location these files using the **fasta** and **gxf** fields:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gff,fastq
-Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gff3,
-Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gff3,
-Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gff3,
+species,refseq,fasta,gxf,fastq
+Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gxf,
+Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gxf,
+Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gxf,
 ```
 
 If running the pipeline using **RefSeq IDs**, indicate the corresponding ID using the **refseq** field:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gff,fastq
+species,refseq,fasta,gxf,fastq
 Homo_sapiens,GCF_000001405.40,,,
 Gorilla_gorilla,GCF_029281585.2,,,
 Pan_paniscus,GCF_029289425.2,,,
@@ -39,10 +41,10 @@ Pan_paniscus,GCF_029289425.2,,,
 If running with **Merqury**, you must point to the location of FASTQ files using the **fastq** field:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gff,fastq
-Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gff3,/path/to/annotation.fastq
-Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gff3,/path/to/annotation.fastq
-Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gff3,/path/to/annotation.fastq
+species,refseq,fasta,gxf,fastq
+Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
+Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
+Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
 ```
 
 As for now, the pipeline doesn't support SRA accession for **Merqury**. We will consider this option  the future.
@@ -52,7 +54,7 @@ As for now, the pipeline doesn't support SRA accession for **Merqury**. We will 
 | `species`  | Species name or custom sample name. Spaces in sample names are automatically converted to underscores (`_`) (not sure if this is an option right now). |
 | `refseq` | RefSeq ID. String has to start with "GCF".                                                             |
 | `fasta` | Full path to the genome fasta file. File has to be gzipped and have the extension ".fasta.gz", ".fna.gz" or ".fa.gz".                                                             |
-| `gff` | Full path to the genome annotation gff file. File has to be gzipped and have the extension ".gff.gz" or ".gff3.gz".                                                             |
+| `gxf` | Full path to the genome annotation gff/gtf file. File has to be gzipped and have the extension ".gtf.gz", ".gff.gz", or ".gff3.gz".                                                             |
 | `fastq` | Full path to FastQ file for long reads (e.g. PacBio or ONT). File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
@@ -103,7 +105,7 @@ You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-c
 ### Modes
 
 #### Genome and annotation (_default_)
-By the default, the pipeline will run on both **genome and annotation**, whether it be from **local files** or **RefSeq IDs**. If RefSeq IDs are not provided, or, alternatively, both local FASTA genome and GFF annotation files are not provided, the pipeline will fail.
+By the default, the pipeline will run on both **genome and annotation**, whether it be from **local files** or **RefSeq IDs**. If RefSeq IDs are not provided, or, alternatively, both local FASTA genome and GXF annotation files are not provided, the pipeline will fail.
 
 #### Genome only
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -49,7 +49,7 @@ params {
     kvalue                     = 21
 
     // BUSCO options
-    busco_mode                 = 'proteins' // Should be hardcoded
+    busco_mode                 = 'proteins' // Only for genome and annotation, genome only is hardcoded
     busco_lineage              = 'hymenoptera_odb10'
     busco_lineages_path        = null
     busco_config               = null

--- a/subworkflows/local/genome_and_annotation.nf
+++ b/subworkflows/local/genome_and_annotation.nf
@@ -14,7 +14,7 @@ workflow GENOME_AND_ANNOTATION {
 
     take:
     ch_fasta // channel: [ val(meta), [ fasta ] ]
-    ch_gff   // channel: [ val(meta), [ gff ] ]
+    ch_gxf   // channel: [ val(meta), [ gxf ] ]
 
     main:
 
@@ -27,35 +27,35 @@ workflow GENOME_AND_ANNOTATION {
     // MODULE: run AGAT convertspgxf2gxf
     //
 
-    // Fix and standarize GFF
-    ch_gff_agat  = AGAT_CONVERTSPGXF2GXF(ch_gff).output_gff
+    // Fix and standarize GXF
+    ch_gxf_agat  = AGAT_CONVERTSPGXF2GXF(ch_gxf).output_gff
 
     //
     // MODULE: Run AGAT longest isoform
     //
 
     LONGEST (
-        ch_gff_agat
+        ch_gxf_agat
     )
     ch_versions  = ch_versions.mix(LONGEST.out.versions.first())
 
-    // Get longest isoform from gff
-    ch_gff_long  = LONGEST.out.longest_proteins
+    // Get longest isoform from gxf
+    ch_gxf_long  = LONGEST.out.longest_proteins
 
     //
     // Prepare input multichannel
     //
 
-    // Combine inputs (fasta, gff from AGAT (unfiltered) and gff from LONGEST (fitlered)))
+    // Combine inputs (fasta, gxf from AGAT (unfiltered) and gxf from LONGEST (fitlered)))
     // into a single multichannel so that they are in sync
     ch_input     = ch_fasta
-                 | combine(ch_gff_agat, by:0) // by:0 | Only combine when both channels share the same id
-                 | combine(ch_gff_long, by:0)
+                 | combine(ch_gxf_agat, by:0) // by:0 | Only combine when both channels share the same id
+                 | combine(ch_gxf_long, by:0)
                  | multiMap {
-                     meta, fasta, gff_unfilt, gff_filt -> // "null" probably not necessary
-                         fasta      : fasta      ? tuple( meta, file(fasta)      ) : null // channel: [ val(meta), [ fasta ] ]
-                         gff_unfilt : gff_unfilt ? tuple( meta, file(gff_unfilt) ) : null // channel: [ val(meta), [ gff ] ], unfiltered
-                         gff_filt   : gff_filt   ? tuple( meta, file(gff_filt)   ) : null // channel: [ val(meta), [ gff ] ], filtered for longest isoform
+                     meta, fasta, gxf_unfilt, gxf_filt ->
+                         fasta      : tuple( meta, file(fasta)      ) // channel: [ val(meta), [ fasta ] ]
+                         gxf_unfilt : tuple( meta, file(gxf_unfilt) ) // channel: [ val(meta), [ gff ] ], unfiltered
+                         gxf_filt   : tuple( meta, file(gxf_filt)   ) // channel: [ val(meta), [ gff ] ], filtered for longest isoform
                  }
 
     //
@@ -63,7 +63,7 @@ workflow GENOME_AND_ANNOTATION {
     //
 
     AGAT_SPSTATISTICS (
-        ch_input.gff_unfilt
+        ch_input.gxf_unfilt
     )
     ch_versions  = ch_versions.mix(AGAT_SPSTATISTICS.out.versions.first())
 
@@ -72,7 +72,7 @@ workflow GENOME_AND_ANNOTATION {
     //
 
     GENE_OVERLAPS {
-        ch_input.gff_filt
+        ch_input.gxf_filt
     }
     ch_tree_data = ch_tree_data.mix(GENE_OVERLAPS.out.overlap_counts.collect { meta, file -> file })
 
@@ -83,7 +83,7 @@ workflow GENOME_AND_ANNOTATION {
     QUAST (
         ch_input.fasta,
         [[],[]],
-        ch_input.gff_unfilt
+        ch_input.gxf_unfilt
     )
     ch_versions  = ch_versions.mix(QUAST.out.versions.first())
 
@@ -96,7 +96,7 @@ workflow GENOME_AND_ANNOTATION {
     //
 
     GFFREAD (
-        ch_input.gff_filt,
+        ch_input.gxf_filt,
         ch_input.fasta.map { meta, fasta -> fasta}
     )
     ch_versions  = ch_versions.mix(GFFREAD.out.versions.first())
@@ -137,7 +137,7 @@ workflow GENOME_AND_ANNOTATION {
 
     BUSCO_BUSCO (
         GFFREAD.out.gffread_fasta,
-        "proteins", // hardcoded
+        params.busco_mode,
         params.busco_lineage,
         params.busco_lineages_path ?: [],
         params.busco_config ?: []
@@ -165,19 +165,19 @@ workflow GENOME_AND_ANNOTATION {
                             [meta.id, fasta]
                         }
 
-    // Prepare GFF channel of ideogram
-    ch_gff_busco        = ch_input.gff_filt
-                        | map { meta, gff ->
-                            [meta.id, gff]
+    // Prepare GXF channel of ideogram
+    ch_gxf_busco        = ch_input.gxf_filt
+                        | map { meta, gxf ->
+                            [meta.id, gxf]
                         }
 
     // Combine BUSCO, AGAT, and genome outputs
     ch_plot_input       = ch_busco_full_table
                         | join(fnaChannel_busco)
-                        | join(ch_gff_busco)
-                        | flatMap { genusspeci, lineages, full_tables, fasta, gff ->
+                        | join(ch_gxf_busco)
+                        | flatMap { genusspeci, lineages, full_tables, fasta, gxf ->
                             lineages.withIndex().collect { lineage, index ->
-                                [genusspeci, lineage, full_tables[index], fasta, gff]
+                                [genusspeci, lineage, full_tables[index], fasta, gxf]
                             }
                         }
 

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -9,7 +9,7 @@ include { MERQURY_MERQURY                     } from '../modules/nf-core/merqury
 include { CREATE_PATH                         } from '../modules/local/create_path'
 include { NCBIGENOMEDOWNLOAD                  } from '../modules/nf-core/ncbigenomedownload/main'
 include { PIGZ_UNCOMPRESS as UNCOMPRESS_FASTA } from '../modules/nf-core/pigz/uncompress/main'
-include { PIGZ_UNCOMPRESS as UNCOMPRESS_GFF   } from '../modules/nf-core/pigz/uncompress/main'
+include { PIGZ_UNCOMPRESS as UNCOMPRESS_GXF   } from '../modules/nf-core/pigz/uncompress/main'
 include { GENOME_ONLY                         } from '../subworkflows/local/genome_only'
 include { GENOME_AND_ANNOTATION               } from '../subworkflows/local/genome_and_annotation'
 include { MULTIQC                             } from '../modules/nf-core/multiqc/main'
@@ -79,15 +79,15 @@ workflow GENOMEQC {
     // Perpare input channels
     //
     
-    // gff. We use mix() here becuase when local files are present,
+    // gxf. We use mix() here becuase when local files are present,
     // then RefSeq IDs should be missing, and viceversa
     fasta = ch_input.local
-            | map { meta, fasta, gff, fq -> tuple( meta, file(fasta) ) }
+            | map { meta, fasta, gxf, fq -> tuple( meta, file(fasta) ) }
             | mix ( NCBIGENOMEDOWNLOAD.out.fna )
  
     // fasta. We use mix() here becuase when local files are present, then RefSeq IDs should be missing, and viceversa
-    gff   = ch_input.local
-            | map { meta, fasta, gff, fq -> tuple( meta, file(gff) ) }
+    gxf   = ch_input.local
+            | map { meta, fasta, gxf, fq -> tuple( meta, file(gxf) ) }
             | mix ( NCBIGENOMEDOWNLOAD.out.gff )
 
 
@@ -100,31 +100,31 @@ workflow GENOMEQC {
     UNCOMPRESS_FASTA (gz_fasta )
     ch_versions = ch_versions.mix(UNCOMPRESS_FASTA.out.versions.first())
 
-    // Filter gff files by extension and create channels for each file type
+    // Filter gxf files by extension and create channels for each file type
 
-    gz_gff     = gff.filter { it[1].name.endsWith(".gz") }
-    non_gz_gff = gff.filter { !it[1].name.endsWith(".gz") }
+    gz_gxf     = gxf.filter { it[1].name.endsWith(".gz") }
+    non_gz_gxf = gxf.filter { !it[1].name.endsWith(".gz") }
 
-    // Run module uncompress_GFF
+    // Run module uncompress_GXF
 
-    UNCOMPRESS_GFF(gz_gff)
-    ch_versions = ch_versions.mix(UNCOMPRESS_GFF.out.versions.first())
+    UNCOMPRESS_GXF(gz_gxf)
+    ch_versions = ch_versions.mix(UNCOMPRESS_GXF.out.versions.first())
 
     // Combine the channels back together so that all the uncompressed files are in channels 
 
     ch_fasta  = UNCOMPRESS_FASTA.out.file.mix(non_gz_fasta)
-    ch_gff    = UNCOMPRESS_GFF.out.file.mix(non_gz_gff)
+    ch_gxf    = UNCOMPRESS_GXF.out.file.mix(non_gz_gxf)
 
     //
     // Define fastq input channel
     //
 
     // FASTQ file is optional in the samplesheet. 
-    // First, get it like you do for gff and fasta
+    // First, get it like you do for gxf and fasta
 
     ch_fastq = ch_input.ncbi
                 | map{ meta, refseq, fq -> tuple( meta, fq ) }
-                | mix( ch_input.local.map{ meta, fasta, gff, fq -> tuple( meta, fq ) } )
+                | mix( ch_input.local.map { meta, fasta, gxf, fq -> tuple( meta, fq ) } )
 
     // Then, check to see that element 1 is not empty, and if not, make it file()
     // You have to do this because if you pass in file() in the initial map, 
@@ -139,16 +139,16 @@ workflow GENOMEQC {
     // Define multi-channel object
     //
 
-    // Combine both fasta, gff and fastq channels into a single multi-channel object using multiMap, so that they are in sync all the time
-    // If element (fasta, gff, fq) is empty, it will return an empty (null) channel
+    // Combine both fasta, gxf and fastq channels into a single multi-channel object using multiMap, so that they are in sync all the time
+    // If element (fasta, gxf, fq) is empty, it will return an empty (null) channel
     ch_input = ch_fasta
-                | combine(ch_gff, by:0) // by:0 | Only combine when both channels share the same id
+                | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
                 | combine(ch_fastq, by:0)
                 | multiMap {
-                    meta, fasta, gff, fq ->
-                        fasta : fasta ? tuple( meta, file(fasta) ) : null // Not sure if conditional is necessary anymore
-                        gff   : gff   ? tuple( meta, file(gff) )   : null
-                        fq    : fq    ? tuple( meta, file(fq) )    : null
+                    meta, fasta, gxf, fq ->
+                        fasta : fasta ? tuple( meta, file(fasta) ) : null
+                        gxf   : gxf   ? tuple( meta, file(gxf) )   : null
+                        fq    : fq    ? tuple( meta, file(fq) )    : null // Only this one is necessary
                 }
 
     //
@@ -199,7 +199,7 @@ workflow GENOMEQC {
     }
 
 
-    // Run genome only or genome + gff
+    // Run genome only or genome + gxf
     if (params.genome_only) {
         GENOME_ONLY (
             ch_input.fasta
@@ -211,7 +211,7 @@ workflow GENOMEQC {
     } else {
         GENOME_AND_ANNOTATION (
             ch_input.fasta,
-            ch_input.gff
+            ch_input.gxf
         )
         ch_multiqc_files = ch_multiqc_files
                          | mix(GENOME_AND_ANNOTATION.out.quast_results.map { meta, results -> results })


### PR DESCRIPTION
Closes #80.

## Changes

Nothing had to be changed, as the pipeline can run on both annotation formats (GTF and GFF). All I did was change some comments and made variables more descriptive (changed gff -> gxf) where I could.

## Comments

The documentation needs to be updated.