### PR TITLE
Use filter to run pipeline on different modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,9 @@
 
 The pipeline takes a list of genomes and annotations (from raw files or Refseq IDs), and runs commonly used tools to assess their quality.
 
-There are three different ways you can run this pipeline:
+There are two ways you can run this pipeline:
  1. Genome only
  2. Annotation only
- 3. Genome and Annotation.
-
-**Currently, only Genome plus Annotation is functional**
 
 <!-- TODO nf-core:
 For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction
@@ -51,18 +48,13 @@ For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#intr
 7. Plots an orthology-based phylogenetic tree : **Tee Summary**, as well as other relevant stats from the above steps.
 8. Summary with [MultiQC](http://multiqc.info).
 
-**2. Genome Only (in development):**
+**2. Genome Only:**
 1. Downloads the genome files from NCBI: [NCBI genome download](https://github.com/kblin/ncbi-genome-download) - Or you provide your own genomes
 2. Describes genome assembly:
    1. [BUSCO](https://busco.ezlab.org/): Evaluates genome completeness based on **single copy markers**.
    2. **BUSCO Ideogram**: Plots the location of markers on the assembly.
    3. [tidk](https://github.com/tolkit/telomeric-identifier) (optional): Indetfies and visualises telomeric repeats.
    3. [QUAST](https://github.com/ablab/quast): Computes contiguity and integrity statistics: N50, N90, GC%, number of sequences.
-3. Summary with [MultiQC](http://multiqc.info).
-
-**3. Annnotation Only (in development):**
-1. Downloads the gene annotation files from NCBI: [NCBI genome download](https://github.com/kblin/ncbi-genome-download) - Or you provide your own annotations.
-2. Describes your annotation : [AGAT](https://agat.readthedocs.io/en/latest/): Gene, feature, length, averages, counts.
 3. Summary with [MultiQC](http://multiqc.info).
 
 > [!WARNING]

--- a/conf/test_genomeonly.config
+++ b/conf/test_genomeonly.config
@@ -1,0 +1,28 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run ecoflow/genomeqc -profile test,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test genome only profile'
+    config_profile_description = 'Minimal test dataset to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    input  = params.pipelines_testdata_base_path + 'genomeqc/samplesheet/input_myco_tiny_genomeonly.csv'
+
+    // BUSCO lienage
+    busco_lineage              = 'mycoplasmatales_odb10'
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,11 +12,6 @@ params {
     // TODO nf-core: Specify your pipeline's command line flags
     // Input options
     input                      = null
-    fasta                      = null
-    // References
-    genome                     = null
-    igenomes_base              = null
-    igenomes_ignore            = false
 
     // tidk options
     skip_tidk                  = false
@@ -232,12 +227,7 @@ plugins {
     id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
-// Load igenomes.config if required
-if (!params.igenomes_ignore) {
-    includeConfig 'conf/igenomes.config'
-} else {
-    params.genomes = [:]
-}
+
 // Export these variables to prevent local Python/R libraries from conflicting with those in the container
 // The JULIA depot path has been adjusted to a fixed path `/usr/local/share/julia` that needs to be used for packages in the container.
 // See https://apeltzer.github.io/post/03-julia-lang-nextflow/ for details on that. Once we have a common agreement on where to keep Julia packages, this is adjustable.

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,7 +40,6 @@ params {
     save_longest_isoform       = false
 
     // merqury/meryl options
-    run_merqury                = false
     kvalue                     = 21
 
     // BUSCO options

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -43,37 +43,6 @@
         }
       }
     },
-    "reference_genome_options": {
-      "title": "Reference genome options",
-      "type": "object",
-      "fa_icon": "fas fa-dna",
-      "description": "Reference genome related files and options required for the workflow.",
-      "properties": {
-        "genome": {
-          "type": "string",
-          "description": "Name of iGenomes reference.",
-          "fa_icon": "fas fa-book",
-          "help_text": "If using a reference genome configured in the pipeline using iGenomes, use this parameter to give the ID for the reference. This is then used to build the full paths for all required reference genome files e.g. `--genome GRCh38`. \n\nSee the [nf-core website docs](https://nf-co.re/usage/reference_genomes) for more details."
-        },
-        "fasta": {
-          "type": "string",
-          "format": "file-path",
-          "exists": true,
-          "mimetype": "text/plain",
-          "pattern": "^\\S+\\.fn?a(sta)?(\\.gz)?$",
-          "description": "Path to FASTA genome file.",
-          "help_text": "This parameter is *mandatory* if `--genome` is not specified. If you don't have a BWA index available this will be generated for you automatically. Combine with `--save_reference` to save BWA index for future runs.",
-          "fa_icon": "far fa-file-code"
-        },
-        "igenomes_ignore": {
-          "type": "boolean",
-          "description": "Do not load the iGenomes reference config.",
-          "fa_icon": "fas fa-ban",
-          "hidden": true,
-          "help_text": "Do not load `igenomes.config` when running the pipeline. You may choose this option if you observe clashes between custom parameters and those supplied in `igenomes.config`."
-        }
-      }
-    },
     "institutional_config_options": {
       "title": "Institutional config options",
       "type": "object",
@@ -328,9 +297,6 @@
   "allOf": [
     {
       "$ref": "#/definitions/input_output_options"
-    },
-    {
-      "$ref": "#/definitions/reference_genome_options"
     },
     {
       "$ref": "#/definitions/institutional_config_options"

--- a/subworkflows/local/genome_and_annotation.nf
+++ b/subworkflows/local/genome_and_annotation.nf
@@ -17,6 +17,7 @@ workflow GENOME_AND_ANNOTATION {
     ch_gxf   // channel: [ val(meta), [ gxf ] ]
 
     main:
+    ch_fasta.view { "Running ${it[0]} on genome and annotation mode"}
 
     ch_versions  = Channel.empty()
 

--- a/subworkflows/local/genome_only.nf
+++ b/subworkflows/local/genome_only.nf
@@ -9,6 +9,7 @@ workflow GENOME_ONLY {
     ch_fasta // channel: [ val(meta), [ fasta ] ]
 
     main:
+    ch_fasta.view { "Running ${it[0]} on genome only mode"}
 
     ch_versions   = Channel.empty()
 

--- a/subworkflows/local/genome_only.nf
+++ b/subworkflows/local/genome_only.nf
@@ -39,7 +39,6 @@ workflow GENOME_ONLY {
         ch_input_ideo
     )
     ch_versions   = ch_versions.mix(GENOME_ONLY_BUSCO_IDEOGRAM.out.versions.first())
-    ch_versions.collect().view()
 
     emit:
     quast_results         = QUAST.out.results                   // channel: [ val(meta), [tsv] ]

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -148,6 +148,7 @@ def validateInputParameters() {
 //
 def validateInputSamplesheet(input) {
     def (meta, refseq, fasta, gff, fastq) = input
+    //println(input)
     if (params.run_merqury && !fastq) { // Perhaps this should be on validateInputParameters()
         error("You are runnning genomeqc using --run_merqury, but no fastq file was found")
     }
@@ -165,10 +166,13 @@ def validateInputSamplesheet(input) {
             error("You are running genomeqc in --genome_only mode, but no fasta file or RefSeq ID was found. Please check input samplesheet -> Incorrect samplesheet format")
         }
     } else {
+        //return [meta, refseq, fasta, gff, fastq]
         if (meta && refseq && !fasta && !gff) {
             return [ meta, refseq, fastq ]
-        } else if ( meta && !refseq && fasta && gff ) {
+        } else if ( meta && !refseq && fasta ) {
             return [ meta, fasta, gff, fastq ]
+        //} else if ( meta && !refseq && fasta && !gff[0] ) {
+        //    return [ meta, fasta, null, fastq ]
         } else {
             error("You are running genomeqc on default mode. Please check input samplesheet -> Incorrent samplesheet format")
         }

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -42,8 +42,8 @@ workflow GENOMEQC {
                     validateInputSamplesheet(it) // Input validation (check local subworkflow)
                 }
                 | branch {
-                    ncbi  : it.size() == 3
-                    local : it.size() == 4
+                    ncbi  : it.size == 3
+                    local : it.size == 4
                 }
 
     // MODULE: Run create_path
@@ -79,15 +79,15 @@ workflow GENOMEQC {
     // Perpare input channels
     //
     
-    // gxf. We use mix() here becuase when local files are present,
-    // then RefSeq IDs should be missing, and viceversa
+    // fasta. We use mix() here becuase when local files are present, then RefSeq IDs should be missing, and viceversa
     fasta = ch_input.local
-            | map { meta, fasta, gxf, fq -> tuple( meta, file(fasta) ) }
+            | map { meta, fasta, gxf, fq -> tuple( meta, file(fasta) ) } // Use file() so that if fasta is not provided pipeline will break
             | mix ( NCBIGENOMEDOWNLOAD.out.fna )
  
-    // fasta. We use mix() here becuase when local files are present, then RefSeq IDs should be missing, and viceversa
+    // gxf. We use mix() here becuase when local files are present,
+    // then RefSeq IDs should be missing, and viceversa
     gxf   = ch_input.local
-            | map { meta, fasta, gxf, fq -> tuple( meta, file(gxf) ) }
+            | map { meta, fasta, gxf, fq ->  tuple ( meta,  gxf ) } // gxf can be empty
             | mix ( NCBIGENOMEDOWNLOAD.out.gff )
 
 
@@ -96,18 +96,15 @@ workflow GENOMEQC {
     non_gz_fasta = fasta.filter { !it[1].name.endsWith(".gz") }
 
     // Run module uncompress_fasta
-
-    UNCOMPRESS_FASTA (gz_fasta )
+    UNCOMPRESS_FASTA ( gz_fasta )
     ch_versions = ch_versions.mix(UNCOMPRESS_FASTA.out.versions.first())
 
     // Filter gxf files by extension and create channels for each file type
-
-    gz_gxf     = gxf.filter { it[1].name.endsWith(".gz") }
-    non_gz_gxf = gxf.filter { !it[1].name.endsWith(".gz") }
+    gz_gxf     = gxf.filter { it[1][0] != null && it[1].name.endsWith(".gz")  }
+    non_gz_gxf = gxf.filter { it[1][0] == null || !it[1].name.endsWith(".gz") }
 
     // Run module uncompress_GXF
-
-    UNCOMPRESS_GXF(gz_gxf)
+    UNCOMPRESS_GXF( gz_gxf )
     ch_versions = ch_versions.mix(UNCOMPRESS_GXF.out.versions.first())
 
     // Combine the channels back together so that all the uncompressed files are in channels 
@@ -141,15 +138,27 @@ workflow GENOMEQC {
 
     // Combine both fasta, gxf and fastq channels into a single multi-channel object using multiMap, so that they are in sync all the time
     // If element (fasta, gxf, fq) is empty, it will return an empty (null) channel
-    ch_input = ch_fasta
-                | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
-                | combine(ch_fastq, by:0)
-                | multiMap {
-                    meta, fasta, gxf, fq ->
-                        fasta : fasta ? tuple( meta, file(fasta) ) : null
-                        gxf   : gxf   ? tuple( meta, file(gxf) )   : null
-                        fq    : fq    ? tuple( meta, file(fq) )    : null // Only this one is necessary
-                }
+    ch_input      = ch_fasta
+                  | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
+                  | combine(ch_fastq, by:0)
+
+    // Split into two channels according to the presence/absence of an annotation
+    ch_input_anno = ch_input.filter { it[2][0] != null } // Will run genome and annotation
+                  | multimapChannel                      // Notice only fasta channel is necessary here
+    ch_input_geno = ch_input.filter { it[2] == null }    // Will run only genome
+                  | multimapChannel // Notice only fasta and gxf channels are necessary here
+    ch_input      = ch_input        // All channels
+                  | multimapChannel
+
+    //ch_input      = ch_fasta
+    //              | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
+    //              | combine(ch_fastq, by:0)
+    //              | multiMap {
+    //                  meta, fasta, gxf, fq ->
+    //                      fasta : fasta ? tuple( meta, file(fasta) ) : null
+    //                      gxf   : gxf   ? tuple( meta, file(gxf) )   : null
+    //                      fq    : fq    ? tuple( meta, file(fq) )    : null // Only this one is necessary
+    //              }
 
     //
     // Run TIDK
@@ -198,7 +207,6 @@ workflow GENOMEQC {
         ch_versions                             = ch_versions.mix(MERQURY_MERQURY.out.versions.first())
     }
 
-
     // Run genome only or genome + gxf
     if (params.genome_only) {
         GENOME_ONLY (
@@ -209,9 +217,12 @@ workflow GENOMEQC {
                          | mix(GENOME_ONLY.out.busco_short_summaries.map { meta, txt -> txt })
         ch_versions      = ch_versions.mix(GENOME_ONLY.out.versions)
     } else {
+        GENOME_ONLY (
+            ch_input_geno.fasta
+        )
         GENOME_AND_ANNOTATION (
-            ch_input.fasta,
-            ch_input.gxf
+            ch_input_anno.fasta,
+            ch_input_anno.gxf
         )
         ch_multiqc_files = ch_multiqc_files
                          | mix(GENOME_AND_ANNOTATION.out.quast_results.map { meta, results -> results })
@@ -298,3 +309,21 @@ workflow GENOMEQC {
     THE END
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
+
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    FUNCTIONS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+def multimapChannel(input) {
+   multi_ch = input
+            | multiMap {
+                meta, fasta, gxf, fq ->
+                    fasta : fasta ? tuple( meta, file(fasta) ) : null
+                    gxf   : gxf   ? tuple( meta, file(gxf) )   : null
+                    fq    : fq    ? tuple( meta, file(fq) )    : null // Only this one is necessary
+            }
+    return multi_ch
+}

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -42,8 +42,8 @@ workflow GENOMEQC {
                     validateInputSamplesheet(it) // Input validation (check local subworkflow)
                 }
                 | branch {
-                    ncbi  : it[1] != null
-                    local : it[1] == null
+                    ncbi  : it.size() == 3
+                    local : it.size() == 4
                 }
 
     // MODULE: Run create_path

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -177,38 +177,36 @@ workflow GENOMEQC {
     // Merqury: Evaluate genome assemblies with k-mers and more
     // https://github.com/marbl/merqury
     // Only run if not skipping and fastq is provided in the samplesheet
-    if (params.run_merqury) {
         // MODULE: MERYL_COUNT
-        MERYL_COUNT(
-            ch_input_merq.fq,
-            params.kvalue 
-        )
-        ch_meryl_db = MERYL_COUNT.out.meryl_db
-        ch_versions = ch_versions.mix(MERYL_COUNT.out.versions.first())
-        // MODULE: MERYL_UNIONSUM
-        MERYL_UNIONSUM(
-            ch_meryl_db,
-            params.kvalue
-        )
-        ch_meryl_union = MERYL_UNIONSUM.out.meryl_db
-        ch_versions    = ch_versions.mix(MERYL_UNIONSUM.out.versions.first())
-        // MODULE: MERQURY_MERQURY
-        ch_merqury_inputs = ch_meryl_union.join(ch_input_merq.fasta)
-        
-        MERQURY_MERQURY ( ch_merqury_inputs )
-        ch_merqury_qv                           = MERQURY_MERQURY.out.assembly_qv
-        ch_merqury_stats                        = MERQURY_MERQURY.out.stats
-        ch_merqury_spectra_cn_fl_png            = MERQURY_MERQURY.out.spectra_cn_fl_png
-        ch_merqury_spectra_asm_fl_png           = MERQURY_MERQURY.out.spectra_asm_fl_png
-        ch_hapmers_blob_png                     = MERQURY_MERQURY.out.hapmers_blob_png
-        ch_merqury_outputs                      = ch_merqury_qv
-                                                | mix(ch_merqury_stats)
-                                                | mix(ch_merqury_spectra_cn_fl_png)
-                                                | mix(ch_merqury_spectra_asm_fl_png)
-                                                | mix(ch_hapmers_blob_png)
-                                                | flatMap { meta, data -> data }
-        ch_versions                             = ch_versions.mix(MERQURY_MERQURY.out.versions.first())
-    }
+    MERYL_COUNT(
+        ch_input_merq.fq,
+        params.kvalue 
+    )
+    ch_meryl_db = MERYL_COUNT.out.meryl_db
+    ch_versions = ch_versions.mix(MERYL_COUNT.out.versions.first())
+    // MODULE: MERYL_UNIONSUM
+    MERYL_UNIONSUM(
+        ch_meryl_db,
+        params.kvalue
+    )
+    ch_meryl_union = MERYL_UNIONSUM.out.meryl_db
+    ch_versions    = ch_versions.mix(MERYL_UNIONSUM.out.versions.first())
+    // MODULE: MERQURY_MERQURY
+    ch_merqury_inputs = ch_meryl_union.join(ch_input_merq.fasta)
+    
+    MERQURY_MERQURY ( ch_merqury_inputs )
+    ch_merqury_qv                           = MERQURY_MERQURY.out.assembly_qv
+    ch_merqury_stats                        = MERQURY_MERQURY.out.stats
+    ch_merqury_spectra_cn_fl_png            = MERQURY_MERQURY.out.spectra_cn_fl_png
+    ch_merqury_spectra_asm_fl_png           = MERQURY_MERQURY.out.spectra_asm_fl_png
+    ch_hapmers_blob_png                     = MERQURY_MERQURY.out.hapmers_blob_png
+    ch_merqury_outputs                      = ch_merqury_qv
+                                            | mix(ch_merqury_stats)
+                                            | mix(ch_merqury_spectra_cn_fl_png)
+                                            | mix(ch_merqury_spectra_asm_fl_png)
+                                            | mix(ch_hapmers_blob_png)
+                                            | flatMap { meta, data -> data }
+    ch_versions                             = ch_versions.mix(MERQURY_MERQURY.out.versions.first())
 
     // Run genome only or genome + gxf
     if (params.genome_only) {

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -39,11 +39,11 @@ workflow GENOMEQC {
 
     ch_input = ch_samplesheet
                 | map {
-                    validateInputSamplesheet(it) // Input validation (check local subworkflow)
+                    validateInputSamplesheet(it) // Input validation (check local subworkflow for how function works)
                 }
-                | branch {
-                    ncbi  : it.size == 3
-                    local : it.size == 4
+                | branch { rows ->
+                    ncbi  : rows.size == 3 // channel: [ val(meta), val(refseq), val(fastq) ]
+                    local : rows.size == 4 // channel: [ val(meta), val(fasta), val(gxf), val(fastq) ]
                 }
 
     // MODULE: Run create_path
@@ -76,44 +76,47 @@ workflow GENOMEQC {
     ch_versions = ch_versions.mix(NCBIGENOMEDOWNLOAD.out.versions.first())
     
     //
-    // Perpare input channels
+    // Perpare fasta channels
     //
     
-    // fasta. We use mix() here becuase when local files are present, then RefSeq IDs should be missing, and viceversa
-    fasta = ch_input.local
-            | map { meta, fasta, gxf, fq -> tuple( meta, file(fasta) ) } // Use file() so that if fasta is not provided pipeline will break
-            | mix ( NCBIGENOMEDOWNLOAD.out.fna )
- 
-    // gxf. We use mix() here becuase when local files are present,
+    // fasta. We use mix() here becuase when local files are present, 
     // then RefSeq IDs should be missing, and viceversa
-    gxf   = ch_input.local
-            | map { meta, fasta, gxf, fq ->  tuple ( meta,  gxf ) } // gxf can be empty
-            | mix ( NCBIGENOMEDOWNLOAD.out.gff )
-
+    fasta        = ch_input.local
+                 | map { meta, fasta, gxf, fq -> tuple( meta, fasta) }
+                 | mix ( NCBIGENOMEDOWNLOAD.out.fna )
 
     // Filter fasta files by extension and create channels for each file type
-    gz_fasta     = fasta.filter { it[1].name.endsWith(".gz") }
-    non_gz_fasta = fasta.filter { !it[1].name.endsWith(".gz") }
+    gz_fasta     = fasta.filter { meta, fasta -> fasta.name.endsWith(".gz") }
+    non_gz_fasta = fasta.filter { meta, fasta -> !fasta.name.endsWith(".gz") }
 
-    // Run module uncompress_fasta
+    // Run module uncompress_fasta and combine channels back 
+    // together so that all the uncompressed files are in channels 
     UNCOMPRESS_FASTA ( gz_fasta )
-    ch_versions = ch_versions.mix(UNCOMPRESS_FASTA.out.versions.first())
-
-    // Filter gxf files by extension and create channels for each file type
-    gz_gxf     = gxf.filter { it[1][0] != null && it[1].name.endsWith(".gz")  }
-    non_gz_gxf = gxf.filter { it[1][0] == null || !it[1].name.endsWith(".gz") }
-
-    // Run module uncompress_GXF
-    UNCOMPRESS_GXF( gz_gxf )
-    ch_versions = ch_versions.mix(UNCOMPRESS_GXF.out.versions.first())
-
-    // Combine the channels back together so that all the uncompressed files are in channels 
-
-    ch_fasta  = UNCOMPRESS_FASTA.out.file.mix(non_gz_fasta)
-    ch_gxf    = UNCOMPRESS_GXF.out.file.mix(non_gz_gxf)
+    ch_fasta     = UNCOMPRESS_FASTA.out.file.mix(non_gz_fasta)
+    ch_versions  = ch_versions.mix(UNCOMPRESS_FASTA.out.versions.first())
 
     //
-    // Define fastq input channel
+    // Perpare gxf channels
+    //
+
+    // gxf. We use mix() here becuase when local files are present,
+    // then RefSeq IDs should be missing, and viceversa
+    gxf         = ch_input.local
+                | map { meta, fasta, gxf, fq ->  tuple( meta,  gxf) }
+                | mix ( NCBIGENOMEDOWNLOAD.out.gff )
+
+    // Filter gxf files by extension and create channels for each file type
+    gz_gxf      = gxf.filter { meta, gxf -> gxf  && gxf.name.endsWith(".gz")  } // Filter non empty and compressed gxf (channel to be uncompressed)
+    non_gz_gxf  = gxf.filter { meta, gxf -> !gxf || !gxf.name.endsWith(".gz") } // Filter empty and uncompressed gxf (not uncompressed)
+
+    // Run module uncompress_GXF and combine channels back 
+    // together so that all the uncompressed files are in channels 
+    UNCOMPRESS_GXF( gz_gxf )
+    ch_gxf      = UNCOMPRESS_GXF.out.file.mix(non_gz_gxf)
+    ch_versions = ch_versions.mix(UNCOMPRESS_GXF.out.versions.first())
+
+    //
+    // Perpare gxf channels
     //
 
     // FASTQ file is optional in the samplesheet. 
@@ -133,32 +136,32 @@ workflow GENOMEQC {
     //    | set {ch_fastq}
     
     //
-    // Define multi-channel object
+    // Define multi-channel objects
     //
 
-    // Combine both fasta, gxf and fastq channels into a single multi-channel object using multiMap, so that they are in sync all the time
+    // Combine both fasta, gxf and fastq channels into a single multi-channel object
+    //  using multiMap, so that they are in sync all the time
     // If element (fasta, gxf, fq) is empty, it will return an empty (null) channel
-    ch_input      = ch_fasta
+    // Check multimapChannel function above
+
+    ch_input      = ch_fasta // channel: [ val(meta), val(fasta), val(gxf), val(fastq) ]
                   | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
                   | combine(ch_fastq, by:0)
 
     // Split into two channels according to the presence/absence of an annotation
-    ch_input_anno = ch_input.filter { it[2][0] != null } // Will run genome and annotation
-                  | multimapChannel                      // Notice only fasta channel is necessary here
-    ch_input_geno = ch_input.filter { it[2] == null }    // Will run only genome
-                  | multimapChannel // Notice only fasta and gxf channels are necessary here
-    ch_input      = ch_input        // All channels
-                  | multimapChannel
+    ch_input_anno = ch_input.filter { meta, fasta, gxf, fastq ->  gxf } // gxf is present. Channel will run on genome and annotation
+                  | multimapChannel // Notice only fasta channel and gxf are necessary here
+    ch_input_geno = ch_input.filter { meta, fasta, gxf, fastq ->  !gxf }// gxf is missing. Channel will run on genome only
+                  | multimapChannel // Notice only fasta channel is necessary here
 
-    //ch_input      = ch_fasta
-    //              | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id
-    //              | combine(ch_fastq, by:0)
-    //              | multiMap {
-    //                  meta, fasta, gxf, fq ->
-    //                      fasta : fasta ? tuple( meta, file(fasta) ) : null
-    //                      gxf   : gxf   ? tuple( meta, file(gxf) )   : null
-    //                      fq    : fq    ? tuple( meta, file(fq) )    : null // Only this one is necessary
-    //              }
+    // For processes not part of genome only or genome and annotation modes
+    // TIDK
+    ch_input_tidk = ch_input
+                  | multimapChannel // Notice only fasta channels are necessary here
+
+    // Merqury
+    ch_input_merq = ch_input.filter { meta, fasta, gxf, fastq -> fastq } // filter rows where fastq is present
+                  | multimapChannel // Notice only fasta and fastq channels are necessary here
 
     //
     // Run TIDK
@@ -166,7 +169,7 @@ workflow GENOMEQC {
     
     if (!params.skip_tidk) {
         FASTA_EXPLORE_SEARCH_PLOT_TIDK (
-            ch_input.fasta,
+            ch_input_tidk.fasta,
             []
         )
     }
@@ -177,7 +180,7 @@ workflow GENOMEQC {
     if (params.run_merqury) {
         // MODULE: MERYL_COUNT
         MERYL_COUNT(
-            ch_input.fq,
+            ch_input_merq.fq,
             params.kvalue 
         )
         ch_meryl_db = MERYL_COUNT.out.meryl_db
@@ -190,7 +193,7 @@ workflow GENOMEQC {
         ch_meryl_union = MERYL_UNIONSUM.out.meryl_db
         ch_versions    = ch_versions.mix(MERYL_UNIONSUM.out.versions.first())
         // MODULE: MERQURY_MERQURY
-        ch_merqury_inputs = ch_meryl_union.join(ch_input.fasta)
+        ch_merqury_inputs = ch_meryl_union.join(ch_input_merq.fasta)
         
         MERQURY_MERQURY ( ch_merqury_inputs )
         ch_merqury_qv                           = MERQURY_MERQURY.out.assembly_qv
@@ -228,7 +231,6 @@ workflow GENOMEQC {
                          | mix(GENOME_AND_ANNOTATION.out.quast_results.map { meta, results -> results })
                          | mix(GENOME_AND_ANNOTATION.out.busco_short_summaries.map { meta, txt -> txt })
         ch_versions      = ch_versions.mix(GENOME_AND_ANNOTATION.out.versions)
-        //ch_versions.view()
 
         //
         // MODULE: Run TREE SUMMARY
@@ -238,7 +240,7 @@ workflow GENOMEQC {
             GENOME_AND_ANNOTATION.out.orthofinder,
             GENOME_AND_ANNOTATION.out.tree_data
         )
-        ch_versions      = ch_versions.mix(TREE_SUMMARY.out.versions.first())
+        ch_versions      = ch_versions.mix(TREE_SUMMARY.out.versions)
     }
 
     //


### PR DESCRIPTION
Closes #118 

## Changes

- Before:
  - To run genome only mode, the flag `--genome_only` had to be set.
- Now:
  - Genome only mode will run by default on those species/samples without annotation (gxf) or RefSeqIDs.
  - Genome and annotation mode will run by default on those species/samples with annotation (gxf) or RefSeqIDs.

## Comments

Input channels are branched according to their origin: **ncbi** and **local**. Once **fasta** and **gff** files have been downloaded using `ncbigenomedownload`, local and `ncbigenomedownload.out` channels are mixed and split according to the file type: one **fasta** channel and one **gxf** channel. These files have to be processed (unzipped) separately, thus the reason why channels are split. Channels are later combined according the their meta ID so that they are in sync, and split again into channels for every process/subworkflow: **genome and annotation**, **genome only**, **tidk** and **merqury**.

The flag `--genome_only` mode can still be used if people want to run the genome only mode on RefSeqIDs and don't care about the annotation. But it might make more sense to just use GenBank IDs for this purpose instead of the flag, so might potentially remove it once genomeqc with GenBanks IDs has been tested.

!NOTE! The same thing should be done for merqury.