### PR TITLE
Download assemblies using genbank accessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 
 **nf-core/genomeqc** is a bioinformatics pipeline that compares the quality of multiple genomes, along with their annotations.
 
-The pipeline takes a list of genomes and annotations (from raw files or Refseq IDs), and runs commonly used tools to assess their quality.
+The pipeline takes a list of genomes and annotations (from local files or ncbi accessions), and runs commonly used tools to assess their quality.
 
-There are two ways you can run this pipeline:
- 1. Genome only
- 2. Annotation only
+Depending on the provided inputs, there are two ways this pipeline can run:
+ 1. Genome only (minmal run, only fasta files are supplied)
+ 2. Genome and Annotation (both fasta and gtf/gff files are supplied)
 
 <!-- TODO nf-core:
 For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#introduction
@@ -29,6 +29,15 @@ For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#intr
 -->
 
 ![pipeline_diagram](docs/images/nf-core-genomeqc_metro_map_v2.png)
+
+**2. Genome Only:**
+1. Downloads the genome files from NCBI: [NCBI genome download](https://github.com/kblin/ncbi-genome-download) - Or you provide your own genomes
+2. Describes genome assembly:
+   1. [BUSCO](https://busco.ezlab.org/): Evaluates genome completeness based on **single copy markers**.
+   2. **BUSCO Ideogram**: Plots the location of markers on the assembly.
+   3. [tidk](https://github.com/tolkit/telomeric-identifier) (optional): Indetfies and visualises telomeric repeats.
+   3. [QUAST](https://github.com/ablab/quast): Computes contiguity and integrity statistics: N50, N90, GC%, number of sequences.
+3. Summary with [MultiQC](http://multiqc.info).
 
 **1. Genome and Annotation:**
 1. Downloads the genome and gene annotation files from NCBI: [NCBI genome download](https://github.com/kblin/ncbi-genome-download) - Or you provide your own genomes/annotations
@@ -48,20 +57,11 @@ For an example, see https://github.com/nf-core/rnaseq/blob/master/README.md#intr
 7. Plots an orthology-based phylogenetic tree : **Tee Summary**, as well as other relevant stats from the above steps.
 8. Summary with [MultiQC](http://multiqc.info).
 
-**2. Genome Only:**
-1. Downloads the genome files from NCBI: [NCBI genome download](https://github.com/kblin/ncbi-genome-download) - Or you provide your own genomes
-2. Describes genome assembly:
-   1. [BUSCO](https://busco.ezlab.org/): Evaluates genome completeness based on **single copy markers**.
-   2. **BUSCO Ideogram**: Plots the location of markers on the assembly.
-   3. [tidk](https://github.com/tolkit/telomeric-identifier) (optional): Indetfies and visualises telomeric repeats.
-   3. [QUAST](https://github.com/ablab/quast): Computes contiguity and integrity statistics: N50, N90, GC%, number of sequences.
-3. Summary with [MultiQC](http://multiqc.info).
-
 > [!WARNING]
 > We strongly suggest users to specify the lineage using the `--busco_lineage` parameter, as setting the lineage to `auto` (default value) might cause problems with `BUSCO` during the lineage determination step.
 
 > [!NOTE]
-> `BUSCO Ideogram` will only plot those chromosomes -or scaffolds- that contain single copy markers.
+> `BUSCO Ideogram` will only plot those chromosomes -or scaffolds- that contain at least one single copy marker.
 
 ## Usage
 
@@ -72,25 +72,24 @@ First, prepare an input **samplesheet** in **csv format** (e.g. `samplesheet.csv
 
 ###  1. Local files
 
-Simply point out to your local genome assembly and annotation (in FASTA and GFF format, respectively) using the `fasta` and `gff` fields, leaving the rest of the fields empty:
+Simply point out to your local genome assembly and annotation (in FASTA and GFF format, respectively) using the `fasta` and `gff` fields:
 
 ```csv
 species,refseq,fasta,gff,fastq
-Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gff3,
-Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gff3,
-Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gff3,
+species_1,,/path/to/genome.fasta,/path/to/annotation.gff3,
+species_2,,/path/to/genome.fasta,/path/to/annotation.gff3,
+species_3,,/path/to/genome.fasta,/path/to/annotation.gff3,
 ```
 
-When running on ``--genome_only`` mode, you can leave the `gff` field empty. Otherwise, this field will be ignored.
+### 2. ncbi accessions
 
-### 2. Refseq IDs
-
-Additionally, you can run the pipeline using the Refseq IDs of the assemblies of interest in the `refseq` field, leaving the rest of the fields empty:
+Additionally, you can run the pipeline using providing ncbi accessions (RefSeq or GenBank, depeding on the mode you wish to run) in the `ncbi` field:
 
 ```csv
 species,refseq,fasta,gff,fastq
-Pongo_abelii,GCF_028885655.2,,,
-Macaca_mulatta,GCF_003339765.1,,,
+species_1,GCF_000000001.1,,,
+species_2,GCF_000000002.1,,,
+species_3,GCF_000000003.1,,,
 ```
 
 ### Run the pipeline

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -14,7 +14,7 @@
             },
             "refseq": {
                 "type": "string",
-                "errorMessage": "RefSeq accession number"
+                "errorMessage": "ncbi accession number"
             },
             "fasta": {
                 "type": "string",

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,7 +19,12 @@ process {
     ]
 
     withName: 'NCBIGENOMEDOWNLOAD' {
-        ext.args = "--format fasta,gff -N"
+        ext.args = {
+            [
+                meta.ncbi == 'refseq'  ? "--section refseq --format fasta,gff -N" : '',
+                meta.ncbi == 'genbank' ? "--section genbank --format fasta -N" : ''
+            ].join(' ').trim()
+        }
         publishDir = [
             path: { "${params.outdir}/ncbigenomedownload" },
             mode: params.publish_dir_mode,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ species_2,,/path/to/genome.fasta,/path/to/annotation.gxf,
 species_3,,/path/to/genome.fasta,/path/to/annotation.gxf,
 species_4,,/path/to/genome.fasta,,/path/to/reads.fastq
 species_5,,/path/to/genome.fasta,,
-species_6,,/path/to/genome.fasta,,
+species_6,,/path/to/genome.fassta,,
 species_7,GCF_000000007.1,,,/path/to/reads.fastq
 species_8,GCF_000000008.1,,,
 species_9,GCA_000000009.1,,,/path/to/reads.fastq

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,7 +6,7 @@
 
 <!-- TODO nf-core: Add documentation about anything specific to running your pipeline. For general topics, please point to (and add to) the main nf-core website. -->
 
-**nf-core/genomeqc** is a pipeline build to aid in the diagnosis of the quality of genome assemblies. It inputs several genomes and/or their respective annotations, and generates metrics such as completness, contiguity, GC% or number of overlapping genes, which can be later used to assess their quality. It outputs a phylogenetic tree with the summary metrics, alongside the MultiQC report. The tree building method uses orthologous genes for a quick comparision of metrics among species/samples. Therefore, this pipeline should not be used for phylogenetic inference.
+**nf-core/genomeqc** is a pipeline build to aid in the diagnosis of the quality of genome assemblies. It inputs several genomes and/or their annotations, and generates metrics such as completness, contiguity, GC% or number of overlapping genes, which can be later used to assess their quality. Additionally, if both genome and annotation are provided, it will output a phylogenetic tree with the summary metrics. The tree building method uses orthologous genes for a quick comparision of metrics among species/samples. This pipeline should not be used for phylogenetic inference.
 
 ## Samplesheet input
 
@@ -16,35 +16,49 @@ Before running the pipeline, you will need to create a samplesheet with informat
 --input '[path to samplesheet file]'
 ```
 
-The content of the samplesheet will depend on the mode you are using to run the pipeline -**genome only** or **genome and annotation**-, the inclusion of FASTQ reads to run **Merqury**, and the origin of the genome assemblies and annotations (**local** or **RefSeq**). Refer to their sections for more information on [running modes](#modes) and [running with **Merqury**](#running-with-merqury). Nonetheless, you must always indicate the species name of each sample using the **species** field.
+The pipeline can be ran using ncbi accessions (RefSeq of GenBank) or local files. It needs at least a **fasta** (GenBank accession or local fasta) file per species to run. If annotations (RefSeq accession or local gtf/gff) are added, the pipeline will run on both **genomes and annotations**. Additionally, if a reads (local fastq) are provided, it will run Merqury.
 
-In **genome and annotation** mode, genome assemblies should be given in FASTA format, whereas feature annotations can be given in GFF or GTF formats (GXF/gxf is used as notation when referring annotation in the documentation).
-
-If running the pipeline on **local** files, point to the location these files using the **fasta** and **gxf** fields:
+If running the pipeline on **local** files, point to the location these files using the **fasta** and/or **gxf** fields:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gxf,fastq
-Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gxf,
-Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gxf,
-Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gxf,
+species,ncbi,fasta,gxf,fastq
+species_1,,/path/to/genome.fasta,/path/to/annotation.gxf,
+species_2,,/path/to/genome.fasta,/path/to/annotation.gxf,
+species_3,,/path/to/genome.fasta,/path/to/annotation.gxf,
 ```
 
-If running the pipeline using **RefSeq IDs**, indicate the corresponding ID using the **refseq** field:
+If running the pipeline using **ncbi acessions (GenBank and/or RefSeq)**, indicate the corresponding ID using the **ncbi** field:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gxf,fastq
-Homo_sapiens,GCF_000001405.40,,,
-Gorilla_gorilla,GCF_029281585.2,,,
-Pan_paniscus,GCF_029289425.2,,,
+species,ncbi,fasta,gxf,fastq
+species_1,GCF_000000001.1,,,
+species_2,GCF_000000002.1,,,
+species_3,GCF_000000003.1,,,
 ```
 
-If running with **Merqury**, you must point to the location of FASTQ files using the **fastq** field:
+If running with **Merqury**, you must point to the location of fastq files using the **fastq** field:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gxf,fastq
-Homo_sapiens,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
-Gorilla_gorilla,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
-Pan_paniscus,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/annotation.fastq
+species,ncbi,fasta,gxf,fastq
+species_1,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq
+species_2,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq
+species_3,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq
+```
+
+You can mix different different input types in the same samplesheet. The pipeline will detect the input type for each species and run accordingly:
+
+```csv title="samplesheet.csv"
+species,ncbi,fasta,gxf,fastq
+species_1,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq
+species_2,,/path/to/genome.fasta,/path/to/annotation.gxf,
+species_3,,/path/to/genome.fasta,/path/to/annotation.gxf,
+species_4,,/path/to/genome.fasta,,/path/to/reads.fastq
+species_5,,/path/to/genome.fasta,,
+species_6,,/path/to/genome.fasta,,
+species_7,GCF_000000007.1,,,/path/to/reads.fastq
+species_8,GCF_000000008.1,,,
+species_9,GCA_000000009.1,,,/path/to/reads.fastq
+species_10,GCA_000000010.1,,,
 ```
 
 As for now, the pipeline doesn't support SRA accession for **Merqury**. We will consider this option  the future.
@@ -52,9 +66,9 @@ As for now, the pipeline doesn't support SRA accession for **Merqury**. We will 
 | Column    | Description                                                                                                                                                                            |
 | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `species`  | Species name or custom sample name. Spaces in sample names are automatically converted to underscores (`_`) (not sure if this is an option right now). |
-| `refseq` | RefSeq ID. String has to start with "GCF".                                                             |
-| `fasta` | Full path to the genome fasta file. File has to be gzipped and have the extension ".fasta.gz", ".fna.gz" or ".fa.gz".                                                             |
-| `gxf` | Full path to the genome annotation gff/gtf file. File has to be gzipped and have the extension ".gtf.gz", ".gff.gz", or ".gff3.gz".                                                             |
+| `ncbi` | ncbi acession. Can be GenBank (starts with "GCA") or RefSeq (starts with "GCF").                                                             |
+| `fasta` | Full path to the genome fasta file. Can be compressed or uncompressed.                                                             |
+| `gxf` | Full path to the genome annotation gff/gtf file. Can be compressed or uncompressed.                                                             |
 | `fastq` | Full path to FastQ file for long reads (e.g. PacBio or ONT). File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                                                             |
 
 An [example samplesheet](../assets/samplesheet.csv) has been provided with the pipeline.
@@ -104,18 +118,39 @@ You can also generate such `YAML`/`JSON` files via [nf-core/launch](https://nf-c
 
 ### Modes
 
-#### Genome and annotation (_default_)
-By the default, the pipeline will run on both **genome and annotation**, whether it be from **local files** or **RefSeq IDs**. If RefSeq IDs are not provided, or, alternatively, both local FASTA genome and GXF annotation files are not provided, the pipeline will fail.
-
 #### Genome only
 
-If the flag ``--genome_only`` is provided, the pipeline will only run on **FASTA genome** files. In this mode, annotation files are not necessary and, if included in the samplesheet, will be ignored.
+This is the minimal run. The pipeline will run on genome only mode if these inputs are provided in the samplesheet:
 
-This mode is less developed than the **genome and annotation** mode.
+1. Path to **fasta** OR
+2. **ncbi** GenaBank accession.
+
+The pipeline will produce a MultiQC report.
+
+#### Genome and annotation
+
+The pipeline will run on genome and annotation mode if these inputs are provided in the samplesheet:
+
+1. Path to **fasta** AND
+2. Path to **gxf** OR
+3. **ncbi** RefSeq accession.
+
+The pipeline will produce a tree plot summary alonside a MultiQC report.
 
 ### Running with Merqury
 
-Optionally, users can also run the pipeline on **genome only** and **genome and annotation** modes by supplying sequencing reads in FASTQ format under the **fastq** field and using the ``--run_merqury`` flag. Refer the [GitHub page](https://github.com/marbl/merqury) for more information on Merqury.
+Users can also run the pipeline using Merqury by supplying the path to sequencing reads under the **fastq** field. Merqury needs both **fasta** and **fastq** to run. Refer the [GitHub page](https://github.com/marbl/merqury) for more information on Merqury.
+
+### Running tests
+
+The pipeline can be ran using different test profiles:
+
+1. `-profile test` Will run on genome and annotation and Merqury using **RefSeq accessions** and local **fastqs**.
+3. `-profile test_local` Will run on genome and annotation on local files (**fasta** and **gxf**).
+4. `-profile test_genomeonly` Will run genome only on local files (**fasta**).
+5. `-profile test_nofastq` Will run genome and annotation using **RefSeq accessions**.
+
+Test files are stored in the genomeqc branch of the [test-dataset repository](https://github.com/nf-core/test-datasets/tree/genomeqc).
 
 ### Updating the pipeline
 

--- a/main.nf
+++ b/main.nf
@@ -19,7 +19,7 @@ include { GENOMEQC  } from './workflows/genomeqc'
 include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_genomeqc_pipeline'
 include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_genomeqc_pipeline'
 
-include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_genomeqc_pipeline'
+//include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_genomeqc_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -168,7 +168,13 @@ def validateInputSamplesheet(input) {
     } else {
         //return [meta, refseq, fasta, gff, fastq]
         if (meta && refseq && !fasta && !gff) {
-            return [ meta, refseq, fastq ]
+            if (refseq.startsWith('GCF')) {
+                return [ [id:meta.id,ncbi:'refseq'], refseq, fastq ]
+            } else if (refseq.startsWith('GCA')) {
+                return [ [id:meta.id,ncbi:'genbank'], refseq, fastq ]
+            } else {
+                error('Incorrect ncbi ID. Please make sure ncbi IDs start with "GCA" for GenBank or "GCG" for RefSeq')
+            }
         } else if ( meta && !refseq && fasta ) {
             return [ meta, fasta, gff, fastq ]
         //} else if ( meta && !refseq && fasta && !gff[0] ) {

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -138,77 +138,57 @@ workflow PIPELINE_COMPLETION {
 //
 // Check and validate pipeline parameters
 //
-def validateInputParameters() {
-    genomeExistsError()
-    // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
-}
+// def validateInputParameters() {
+//    genomeExistsError()
+//    // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
+//}
 
 //
 // Validate channels from input samplesheet
 //
 def validateInputSamplesheet(input) {
-    def (meta, refseq, fasta, gff, fastq) = input
-    //println(input)
-    if (params.run_merqury && !fastq) { // Perhaps this should be on validateInputParameters()
-        error("You are runnning genomeqc using --run_merqury, but no fastq file was found")
-    }
-    // As for now, there are only two input options: RefSeq ID or local files.
-    // The pipeline will throw an error if the sample sheet does not contain
-    // the proper information
-    // If --genome_only parameter
-    // Check for genome-only mode
-    if (params.genome_only) {
-        if (meta && refseq && !fasta && !gff) {
-            return [meta, refseq, fastq]
-        } else if (meta && !refseq && fasta) {
-            return [meta, fasta, gff, fastq] // Empty or not gff, either way won't be used
+    def ( meta, ncbi, fasta, gff, fastq ) = input
+    // If input are ncbi accessions
+    if ( meta && ncbi ) {
+        if ( ncbi.startsWith('GCF') ) { // For refseq IDs
+            return [ [id:meta.id,ncbi:'refseq'], ncbi, fastq ]
+        } else if ( ncbi.startsWith('GCA') ) { // For genbank IDs
+            return [ [id:meta.id,ncbi:'genbank'], ncbi, fastq ]
         } else {
-            error("You are running genomeqc in --genome_only mode, but no fasta file or RefSeq ID was found. Please check input samplesheet -> Incorrect samplesheet format")
+            error('Incorrect ncbi ID. Please make sure ncbi IDs start with "GCA" for GenBank or "GCG" for RefSeq')
         }
+    // If input are local files
+    } else if ( meta && fasta ) { // At least fasta file is necessary if local files (genome only mode is the minimum run)
+        return [ meta, fasta, gff, fastq ]
     } else {
-        //return [meta, refseq, fasta, gff, fastq]
-        if (meta && refseq && !fasta && !gff) {
-            if (refseq.startsWith('GCF')) {
-                return [ [id:meta.id,ncbi:'refseq'], refseq, fastq ]
-            } else if (refseq.startsWith('GCA')) {
-                return [ [id:meta.id,ncbi:'genbank'], refseq, fastq ]
-            } else {
-                error('Incorrect ncbi ID. Please make sure ncbi IDs start with "GCA" for GenBank or "GCG" for RefSeq')
-            }
-        } else if ( meta && !refseq && fasta ) {
-            return [ meta, fasta, gff, fastq ]
-        //} else if ( meta && !refseq && fasta && !gff[0] ) {
-        //    return [ meta, fasta, null, fastq ]
-        } else {
-            error("You are running genomeqc on default mode. Please check input samplesheet -> Incorrent samplesheet format")
-        }
+        error("You are running genomeqc on default mode. Please check input samplesheet -> Incorrent samplesheet format")
     }
 }
 //
 // Get attribute from genome config file e.g. fasta
 //
-def getGenomeAttribute(attribute) {
-    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
-        if (params.genomes[ params.genome ].containsKey(attribute)) {
-            return params.genomes[ params.genome ][ attribute ]
-        }
-    }
-    return null
-}
+//def getGenomeAttribute(attribute) {
+//    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
+//        if (params.genomes[ params.genome ].containsKey(attribute)) {
+//            return params.genomes[ params.genome ][ attribute ]
+//        }
+//    }
+//    return null
+//}
 
 //
 // Exit pipeline if incorrect --genome key provided
 //
-def genomeExistsError() {
-    if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
-        def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
-            "  Genome '${params.genome}' not found in any config files provided to the pipeline.\n" +
-            "  Currently, the available genome keys are:\n" +
-            "  ${params.genomes.keySet().join(", ")}\n" +
-            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
-        error(error_string)
-    }
-}
+//def genomeExistsError() {
+//    if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
+//        def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+//            "  Genome '${params.genome}' not found in any config files provided to the pipeline.\n" +
+//            "  Currently, the available genome keys are:\n" +
+//            "  ${params.genomes.keySet().join(", ")}\n" +
+//            "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+//       error(error_string)
+//    }
+//}
 
 //
 // Generate methods description for MultiQC

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -138,10 +138,10 @@ workflow PIPELINE_COMPLETION {
 //
 // Check and validate pipeline parameters
 //
-// def validateInputParameters() {
-//    genomeExistsError()
-//    // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
-//}
+def validateInputParameters() {
+    //genomeExistsError()
+    // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
+}
 
 //
 // Validate channels from input samplesheet

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -126,23 +126,14 @@ workflow GENOMEQC {
                 | map{ meta, refseq, fq -> tuple( meta, fq ) }
                 | mix( ch_input.local.map { meta, fasta, gxf, fq -> tuple( meta, fq ) } )
 
-    // Then, check to see that element 1 is not empty, and if not, make it file()
-    // You have to do this because if you pass in file() in the initial map, 
-    // it'll fail if you don't supply a fastq, because you can't pass an empty to file()
-
-    //ch_fastq
-    //    | map{meta, fq -> fq ? [meta, file(fq)] : [meta, fq]}
-    //    | filter { meta, fq -> fq && fq.name =~ /(\.fastq|\.fq|\.fastq\.gz|\.fq\.gz)$/ }
-    //    | set {ch_fastq}
-    
     //
-    // Define multi-channel objects
+    // Define multi-channel objects for every process/subworkflow
     //
 
     // Combine both fasta, gxf and fastq channels into a single multi-channel object
-    //  using multiMap, so that they are in sync all the time
+    // using multiMap, so that they are in sync
     // If element (fasta, gxf, fq) is empty, it will return an empty (null) channel
-    // Check multimapChannel function above
+    // Check multimapChannel function below
 
     ch_input      = ch_fasta // channel: [ val(meta), val(fasta), val(gxf), val(fastq) ]
                   | combine(ch_gxf, by:0) // by:0 | Only combine when both channels share the same id


### PR DESCRIPTION
Closes #131 

## Changes

Now, users can choose to download assemblies using:
- **GenBank accessions**: Will download genome and run on genome only mode
-  **RefSeq accessions**: Will download both genome and annotation and run on genome and annotation mode

## Comments

### How it works

Before running `NCBIGENOMEDOWNLOAD`, the input validation function checks the first three letters of the string in the `refseq` field (this should be renamed to `ncbi`):
- If it starts with `"GCF"`, it will add a new element to the meta: `ncbi:"refseq"`
- If it starts with `"GCA"`, it will add a new element to the meta: `ncbi:"genbank"`

This new meta value is used to set the appropriate arguments for `NCBIGENOMEDOWNLOAD` (check `modules.config`).

