### PR TITLE
Change refseq to ncbi

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ species_3,/path/to/genome3.fasta,/path/to/annotation3.gff3
 
 ### 2. ncbi accessions
 
-Additionally, you can run the pipeline providing ncbi accessions (RefSeq or GenBank, depeding on the mode you wish to run) in the `refseq` field:
+Additionally, you can run the pipeline providing ncbi accessions (RefSeq or GenBank, depeding on the mode you wish to run) in the `ncbi` field:
 
 ```csv
-species,refseq
+species,ncbi
 species_1,GCF_000000001.1
 species_2,GCF_000000002.1
 species_3,GCF_000000003.1
@@ -114,7 +114,7 @@ species_3,GCF_000000003.1
 You can combine both input types in the same samplesheet:
 
 ```csv
-species,refseq,fasta,gff
+species,ncbi,fasta,gff
 species_1,GCF_000000001.1
 species_2,,/path/to/genome2.fasta,/path/to/annotation2.gff3
 species_3,GCF_000000003.1

--- a/assets/input_bacteria_taxid.csv
+++ b/assets/input_bacteria_taxid.csv
@@ -1,4 +1,4 @@
-species,refseq,fasta,gff,fastq,taxid
+species,ncbi,fasta,gff,fastq,taxid
 Mycoplasmoides_fastidiosum,GCF_024498275.1,,,,1245
 Mycoplasmoides_gallisepticum,GCF_017654545.1,,,,1245
 Mycoplasmoides_pneumoniae,GCF_000733995.1,,,,1245

--- a/assets/samplesheet.csv
+++ b/assets/samplesheet.csv
@@ -1,2 +1,2 @@
-species,refseq,fasta,gff,fastq,taxid
+species,ncbi,fasta,gff,fastq,taxid
 test_combo,,/Users/fernando/work/repositories/pipelines/fcx_test/FCS_combo_test.fa,,,4932

--- a/assets/samplesheet_decon.csv
+++ b/assets/samplesheet_decon.csv
@@ -1,2 +1,2 @@
-species,refseq,fasta,gff,fastq,taxid
+species,ncbi,fasta,gff,fastq,taxid
 test_combo,,https://zenodo.org/records/10932013/files/FCS_combo_test.fa,,,4932

--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -13,7 +13,7 @@
                 "pattern": "^\\S+$",
                 "meta": ["id"]
             },
-            "refseq": {
+            "ncbi": {
                 "type": "string",
                 "pattern": "^GC[AF]_[0-9]{9}\\.[0-9]+$",
                 "errorMessage": "NCBI assembly accession number. Should start with GCA_ (RefSeq) or GFC_ (GenBank), followed by 9 digits and the version number, and cannot contain spaces"

--- a/conf/test_decon.config
+++ b/conf/test_decon.config
@@ -10,14 +10,17 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    resourceLimits = [
+        cpus: 2,
+        memory: '4.GB',
+        time: '6.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Decontamination test profile'
     config_profile_description = 'Minimal test dataset to check pipeline decontamination screening step'
-
-    // Test resources
-    max_cpus   = 2
-    max_memory = '4.GB'
-    max_time   = '6.h'
 
     // Input data
     input  = 'assets/samplesheet_decon.csv'

--- a/conf/test_genomeonly.config
+++ b/conf/test_genomeonly.config
@@ -10,14 +10,17 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    resourceLimits = [
+        cpus: 2,
+        memory: '6.GB',
+        time: '6.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test genome only profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = '6.GB'
-    max_time   = '6.h'
 
     // Input data
     input  = params.pipelines_testdata_base_path + 'genomeqc/samplesheet/input_myco_tiny_genomeonly.csv'

--- a/conf/test_local.config
+++ b/conf/test_local.config
@@ -22,11 +22,6 @@ params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = '6.GB'
-    max_time   = '6.h'
-
     // Input data
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed

--- a/conf/test_nofastq.config
+++ b/conf/test_nofastq.config
@@ -10,14 +10,17 @@
 ----------------------------------------------------------------------------------------
 */
 
+process {
+    resourceLimits = [
+        cpus: 2,
+        memory: '6.GB',
+        time: '6.h'
+    ]
+}
+
 params {
     config_profile_name        = 'Test profile'
     config_profile_description = 'Minimal test dataset to check pipeline function'
-
-    // Limit resources so that this can run on GitHub Actions
-    max_cpus   = 2
-    max_memory = '6.GB'
-    max_time   = '6.h'
 
     // Input data
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets

--- a/docs/output.md
+++ b/docs/output.md
@@ -6,8 +6,6 @@ This document describes the output produced by the nf-core/genomeqc.
 
 The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
 
-<!-- TODO nf-core: Write this documentation describing your workflow's output -->
-
 ## Pipeline overview
 
 The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes data using the following steps:
@@ -16,27 +14,27 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 <!-- [FastaValidator](#fastavalidator) Validate FASTA files -->
 <!-- [AGAT convert sp_GXF2GXF]() - Standataizes gff files -->
 
-- [NCBI genome download](#ncbi-genome-download) - Download genomes and their annotations from RefSeq
+- [NCBI genome download](#ncbi-genome-download) - Download genomes and their annotations from RefSeq and GenBank.
 - Genome quality metrics:
-  - [Quast](#quast) - Genome quality and contiguity metrics
-  - [tidk](#tidk) - Identify telomeric repeats
-  - [Merqury](#merqury) - Genome completeness and accuracy based on raw sequecing k-mer counts
+  - [Quast](#quast) - Genome quality and contiguity metrics.
+  - [tidk](#tidk) - Identify telomeric repeats.
+  - [Merqury](#merqury) - Genome completeness and accuracy based on raw sequecing k-mer counts.
 - Annotation quality metrics:
-  - [AGAT sp_statistics](#agat-sp_statistics) - Gene statistics
-  - [AGAT sp_keep_longest_isoform](#agat-sp_keep_longest_isoform) - Filter longest isoform from GXF file
-  - [Gene overlaps](#gene-overlaps) - Find overlapping genes (sense and antisense)
+  - [AGAT sp_statistics](#agat-sp_statistics) - Gene statistics.
+  - [AGAT sp_keep_longest_isoform](#agat-sp_keep_longest_isoform) - Filter longest isoform from GXF file.
+  - [Gene overlaps](#gene-overlaps) - Find overlapping genes (sense and antisense).
 - [Decontamination](#decontamination):
-  - [FCS-GX](#fcs-gx) - Foreign genome contamination screening
-  - [FCS-adaptor](#fcs-adaptor) - Adaptor and vector contamination screening
-  - [FCS-adaptor clean genome](#fcs-adaptor-clean-genome) Removal of contamination from assembly
-  - [Tiara](#tiara) - Sequence classification (domain and organelle level)
-- [GffRead](#gffread) - Extract longest isoform from FASTA file
-- [BUSCO](#busco) - Genome completeness based on single copy markers
-- [Orthofinder](#orthofinder) - Phylogenetic orthology inference
-- [Tree summary](#tree-summary) - Phylogenetic summary plot
-- [Shiny app](#shiny-app) - Dynamic tree summary plot adjuster
-- [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline
-- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution
+  - [FCS-GX](#fcs-gx) - Foreign genome contamination screening.
+  - [FCS-adaptor](#fcs-adaptor) - Adaptor and vector contamination screening.
+  - [FCS-adaptor clean genome](#fcs-adaptor-clean-genome) Removal of contamination from assembly.
+  - [Tiara](#tiara) - Sequence classification (domain and organelle level).
+- [GffRead](#gffread) - Extract longest isoform from FASTA file.
+- [BUSCO](#busco) - Genome completeness based on single copy markers.
+- [Orthofinder](#orthofinder) - Phylogenetic orthology inference.
+- [Tree summary](#tree-summary) - Phylogenetic summary plot.
+- [Shiny app](#shiny-app) - Dynamic tree summary plot adjuster.
+- [MultiQC](#multiqc) - Aggregate report describing results and QC from the whole pipeline.
+- [Pipeline information](#pipeline-information) - Report metrics generated during the workflow execution.
 
 <!--### Pigz Uncompress
 
@@ -113,14 +111,14 @@ It outputs a report with each sequence of the genome assembly labelled as Eukary
 
 [NCBI genome download](https://github.com/kblin/ncbi-genome-download) is a tool for downloading assemblies from the NCBI FTP site.
 
-It inputs RefSeq IDs and downloads the respective assembly and annotation in FASTA and GFF formats. If local files are provided, this step is skipped.
+It inputs RefSeq or GeneBank assembly accessions and downloads the respective assembly (RefSeq and GeneBank) and annotation (RefSeq only) in FASTA and GFF formats. If local files are provided, this step is skipped.
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `ncbigenomedownload/`
-  - `<assembly>.fa.gz`: Genome assembly in FASTA format.
-  - `<assembly>.gff3.gz`: Annotation in GFF format.
+  - `<assembly>.fa.gz`: Genome assembly in FASTA format (GeneBank and RefSeq outputs).
+  - `<assembly>.gff3.gz`: Annotation in GFF format (RefSeq output).
 
 </details>
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,10 +27,10 @@ species_2,/path/to/genome2.fasta,/path/to/annotation2.gxf
 species_3,/path/to/genome3.fasta,/path/to/annotation3.gxf
 ```
 
-If running the pipeline using **ncbi accessions (GenBank and/or RefSeq)**, indicate the corresponding ID using the **refseq** field:
+If running the pipeline using **ncbi accessions (GenBank and/or RefSeq)**, indicate the corresponding ID using the `ncbi` field:
 
 ```csv title="samplesheet.csv"
-species,refseq
+species,ncbi
 species_1,GCF_000000001.1
 species_2,GCF_000000002.1
 species_3,GCF_000000003.1
@@ -58,7 +58,7 @@ species_3,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq,432
 This is what the complete samplesheet would look like if using local files, and adding FASTQ paths and tax IDs:
 
 ```csv title="samplesheet.csv"
-species,refseq,fastq,taxid
+species,ncbi,fastq,taxid
 species_1,GCF_000000001.1,/path/to/reads.fastq,1234
 species_2,GCF_000000002.1,/path/to/reads.fastq,1245
 species_3,GCF_000000003.1,/path/to/reads.fastq,4321
@@ -67,7 +67,7 @@ species_3,GCF_000000003.1,/path/to/reads.fastq,4321
 You can mix different input types in the same samplesheet. If a specific field doesn’t apply to a row, leave it empty (as shown below). The pipeline will automatically detect the input type for each row and run the appropiate subworkflow:
 
 ```csv title="samplesheet.csv"
-species,refseq,fasta,gff,fastq,taxid
+species,ncbi,fasta,gff,fastq,taxid
 species_1,,/path/to/genome.fasta,/path/to/annotation.gxf,/path/to/reads.fastq,1234
 species_2,,/path/to/genome.fasta,/path/to/annotation.gxf,,4321
 species_3,,/path/to/genome.fasta,/path/to/annotation.gxf,
@@ -85,7 +85,7 @@ As for now, the pipeline doesn't support SRA accession for **Merqury**. We will 
 | Column    | Description                                                                                                                                            |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `species` | Species name or custom sample name. Spaces in sample names are automatically converted to underscores (`_`). |
-| `refseq`  | ncbi acession. Can be GenBank (starts with `GCA`) or RefSeq (starts with `GCF`).                                                                       |
+| `ncbi`  | ncbi acession. Can be GenBank (starts with `GCA`) or RefSeq (starts with `GCF`).                                                                       |
 | `fasta`   | Full path to the genome fasta file. Can be compressed or uncompressed.                                                                                 |
 | `gff`     | Full path to the genome annotation gff/gtf file. Can be compressed or uncompressed.                                                                    |
 | `fastq`   | Full path to FastQ file for long reads (e.g. PacBio or ONT). File has to be gzipped and have the extension ".fastq.gz" or ".fq.gz".                    |

--- a/nextflow.config
+++ b/nextflow.config
@@ -87,7 +87,7 @@ params {
     help_full                    = false
     show_hidden                  = false
     version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Eco-Flow/test-datasets/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/'
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 
     // Config options

--- a/nextflow.config
+++ b/nextflow.config
@@ -87,7 +87,7 @@ params {
     help_full                    = false
     show_hidden                  = false
     version                      = false
-    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/nf-core/test-datasets/'
+    pipelines_testdata_base_path = 'https://raw.githubusercontent.com/Eco-Flow/test-datasets/'
     trace_report_suffix          = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 
     // Config options


### PR DESCRIPTION
Closes #138.

## Changes

Changed the `refseq` field to `ncbi` in the documentation, schema input, and samplesheets.

`ncbi` is a more descriptive name for the filed.

## Comments

Tests are not going to work as the samplesheets still have the old `refseq` filed. I'll open a new PR in nf-core/test-datasets to change this. Once it has been changed, this PR can and should be merged.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
