### PR TITLE
Fixed BUSCO not showing in tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Initial release of nf-core/genomeqc, created with the [nf-core](https://nf-co.re
 
 ### `Fixed`
 
+- Fixed BUSCO not showing in the tree
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -240,7 +240,7 @@ process {
 
     withName: 'GENOME_ANNOTATION_BUSCO_IDEOGRAM' {
         publishDir = [
-            path: { "${params.outdir}/busco/${meta}/ideogram" },
+            path: { "${params.outdir}/busco/${genusspeci}_${lineage}/ideogram" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -247,7 +247,7 @@ process {
 
     withName: 'GENOME_ONLY_BUSCO_IDEOGRAM' {
         publishDir = [
-            path: { "${params.outdir}/busco/${genusspeci}_${lineage}/ideogram/" },
+            path: { "${params.outdir}/busco/${meta}/ideogram/" },
             mode: params.publish_dir_mode
         ]
     }

--- a/workflows/genomeqc.nf
+++ b/workflows/genomeqc.nf
@@ -177,7 +177,7 @@ workflow GENOMEQC {
             ch_input_decon,
             params.ramdisk ?: [],
             params.gxdb ?: [],
-            file(params.gxdb_manifiest) ?: []
+            params.gxdb_manifiest ? file(params.gxdb_manifiest) : []
         )
     }
 
@@ -290,6 +290,12 @@ workflow GENOMEQC {
                                     geno      : geno_files ? tuple( meta, geno_files ) : [[],[]]
                                     prot      : prot_files ? tuple( meta, prot_files ) : [[],[]]
                             }
+        // Prepare busco channel for genome only
+        ch_busco_geno       = GENOME_ONLY.out.busco_short_summaries
+                            | map { _meta, file -> file }
+                            | collect
+                            | map { files -> tuple( [id:"busco_geno"], files )}
+                            | ifEmpty([[],[]]) // If no busco results are found, return an empty channel instead of failing
 
         // Run TREE SUMMARY for genome and annotation
         TREE_SUMMARY_GENO_ANNO (
@@ -302,7 +308,7 @@ workflow GENOMEQC {
         // Run TREE SUMMARY for genome only
         TREE_SUMMARY_GENO (
             GENOME_ONLY.out.orthofinder,
-            [[],[]], // No busco for genome only (busco runs on genome)
+            ch_busco_geno, // If no busco results are found, return an empty channel instead of failing
             [[],[]], // No busco for genome only (busco runs on genome)
             ch_tree_genome
         )


### PR DESCRIPTION
No issues related to this PR.

## Changes

- This is just a quick fix, as BUSCO for genome inputs was not showing in the tree.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/main/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
