### PR TITLE
Add author/licence headers to bin scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ results/
 testing/
 testing*
 *.pyc
+__pycache__/
 null/
 .lineage/

--- a/bin/busco_create_table_for_plot.R
+++ b/bin/busco_create_table_for_plot.R
@@ -1,5 +1,8 @@
 #!/usr/bin/env Rscript
 
+# Written by Fernando Duarte and released under the MIT license.
+# Builds a BUSCO table matched to a GFF for downstream plotting
+
 # Load required libraries
 suppressMessages(library(dplyr))
 suppressMessages(library(readr))

--- a/bin/gene_overlaps.R
+++ b/bin/gene_overlaps.R
@@ -1,6 +1,6 @@
 #!/usr/bin/env Rscript
 
-# Code written by Chris Wyatt with some editing by ChatGPT
+# Written by Chris Wyatt with AI assistance, released under the MIT license.
 
 library(dplyr)
 library(GenomicRanges)

--- a/bin/gene_overlaps_table.py
+++ b/bin/gene_overlaps_table.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
-# Written using ChatGPT
+# Written by Fernando Duarte with AI assistance, released under the MIT license.
+# Extracts gene overlap statistics from per-sample files into a combined table
 
 import pandas as pd
 import argparse

--- a/bin/ortho_seqs.py
+++ b/bin/ortho_seqs.py
@@ -5,7 +5,7 @@
 # the results from different samples/species into a
 # single table
 
-# Credits to ChatGPT
+# Written by Fernando Duarte with AI assistance, released under the MIT license.
 
 import argparse
 import os

--- a/bin/plot_busco_ideogram.R
+++ b/bin/plot_busco_ideogram.R
@@ -1,6 +1,8 @@
 #!/usr/bin/env Rscript
 
-# Script adapted from: https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers2.R?ref_type=heads
+# Adapted by Fernando Duarte from ezlab busco_protocol; local modifications released under the MIT license.
+# Upstream source (no explicit license stated upstream as of 2026-07):
+# https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers2.R?ref_type=heads
 
 # Load required libraries
 library(optparse)

--- a/bin/plot_busco_ideogram_kayrotyope_setup.R
+++ b/bin/plot_busco_ideogram_kayrotyope_setup.R
@@ -1,9 +1,11 @@
 #!/usr/bin/env Rscript
 
+# Adapted by Fernando Duarte from ezlab busco_protocol; local modifications released under the MIT license.
+# Upstream source (no explicit license stated upstream as of 2026-07):
+# https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers2.R?ref_type=heads
+
 # load libraries
 library(RIdeogram)
-
-# Script adapted from: https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers2.R?ref_type=heads
 
 args <- commandArgs(trailingOnly = TRUE)
 file_name_for_karyotype <- args[1]

--- a/bin/plot_markers1.R
+++ b/bin/plot_markers1.R
@@ -1,6 +1,8 @@
 #!/usr/bin/env Rscript
 
-# Modified from https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers1.R?ref_type=heads
+# Adapted by Fernando Duarte from ezlab busco_protocol; local modifications released under the MIT license.
+# Upstream source (no explicit license stated upstream as of 2026-07):
+# https://gitlab.com/ezlab/busco_protocol/-/blob/main/support_protocol2/plot_markers/scripts/plot_markers1.R?ref_type=heads
 
 # load libraries
 require(RIdeogram)

--- a/bin/shiny_app.R
+++ b/bin/shiny_app.R
@@ -1,3 +1,4 @@
+# Written by Fernando Duarte and released under the MIT license.
 #
 # This is a Shiny web application. You can run the application by clicking
 # the 'Run App' button above.


### PR DESCRIPTION
Add proper author + MIT licence lines to bin scripts that were missing them, note AI assistance where relevant, and preserve upstream ezlab busco_protocol attribution (upstream has no explicit licence). Also ignore __pycache__/.

