### PR TITLE
Fixed te subworkflow not working

### DIFF
--- a/modules/local/buscos_seqs/main.nf
+++ b/modules/local/buscos_seqs/main.nf
@@ -4,7 +4,7 @@ process BUSCO_SEQS {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/pandas_python:cb09ca6c506f826e'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/91/91aa49b5e9a716c3927f05879c11b356e0f1d3bdcbff9b117095f63506b5d4c3/data'
         : 'community.wave.seqera.io/library/python_pip_pandas:2fd05a70c67560f2'}"
 
     input:

--- a/modules/local/genomeannotationbuscoideogram/main.nf
+++ b/modules/local/genomeannotationbuscoideogram/main.nf
@@ -4,8 +4,8 @@ process GENOMEANNOTATIONBUSCOIDEOGRAM {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/r-base_seqkit_r-rideogram_r-optparse_pruned:db707efb147636c0'
-        : 'community.wave.seqera.io/library/r-base_seqkit_r-rideogram_r-optparse_pruned:07dcf079214428f3' }"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d4/d4e58ef54f830d8efd697670b69953ef30b5165b812c1e0e80943e075af4b106/data'
+        : 'community.wave.seqera.io/library/r-base_seqkit_r-rideogram_r-optparse_pruned:381d161bd6bee823' }"
 
     input:
     tuple val(genusspeci), val(lineage), path(busco_full_table), path(genome), path(gff)

--- a/modules/local/genomebuscoideogram/environment.yml
+++ b/modules/local/genomebuscoideogram/environment.yml
@@ -10,3 +10,5 @@ dependencies:
   - r-optparse=1.7.5
   - r-ggplot2=3.5.1
   - r-readr=2.1.5
+  - r-dplyr=1.2.1
+  - r-stringr=1.6.0

--- a/modules/local/genomebuscoideogram/main.nf
+++ b/modules/local/genomebuscoideogram/main.nf
@@ -4,8 +4,8 @@ process GENOMEBUSCOIDEOGRAM {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/seqkit_r-ggplot2_r-optparse_r-rideogram:dd27bf2f09a9ac59'
-        : 'community.wave.seqera.io/library/seqkit_r-ggplot2_r-optparse_r-rideogram:38eaba661baaec00' }"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/d4/d4e58ef54f830d8efd697670b69953ef30b5165b812c1e0e80943e075af4b106/data'
+        : 'community.wave.seqera.io/library/r-base_seqkit_r-rideogram_r-optparse_pruned:381d161bd6bee823' }"
 
     input:
     tuple val(meta), path(genome), path(busco_full_table)

--- a/modules/local/orthologous_chromosomes/main.nf
+++ b/modules/local/orthologous_chromosomes/main.nf
@@ -4,7 +4,7 @@ process ORTHOLOGOUS_CHROMOSOMES {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/pandas_python:cb09ca6c506f826e'
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/91/91aa49b5e9a716c3927f05879c11b356e0f1d3bdcbff9b117095f63506b5d4c3/data'
         : 'community.wave.seqera.io/library/python_pip_pandas:2fd05a70c67560f2'}"
 
     input:

--- a/modules/local/shiny_app/environment.yml
+++ b/modules/local/shiny_app/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - conda-forge::coreutils=8.32
+  - coreutils=8.31

--- a/modules/local/treesummary/main.nf
+++ b/modules/local/treesummary/main.nf
@@ -4,8 +4,8 @@ process TREESUMMARY {
 
     conda "${moduleDir}/environment.yml"
     container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'oras://community.wave.seqera.io/library/python_pandas_r-base_bioconductor-ggtree_pruned:8c55bd10cfed7ddf'
-        : 'community.wave.seqera.io/library/python_pandas_r-base_bioconductor-ggtree_pruned:c663395a0c48f3ef'}"
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/22/222cecd2ebec39f4c73b3b8608ffddd0bfae8a9b5aad392ab4da1e75d25a5e9e/data'
+        : 'community.wave.seqera.io/library/python_pandas_r-base_bioconductor-ggtree_pruned:f9ab550d092fa61d'}"
 
     input:
     tuple val(meta), path(tree)

--- a/subworkflows/local/fasta_annotate_te/main.nf
+++ b/subworkflows/local/fasta_annotate_te/main.nf
@@ -37,7 +37,8 @@ workflow FASTA_ANNOTATE_TE {
     if (params.te == 'repeatmasker') {
         // MODULE: RM_DOWNLOAD_DB
         // Download h5 partition files from DFAM — versions flow via Channel.topic('versions')
-        RM_DOWNLOAD_DB ( ch_rm_db )
+        // skip if ch_rm_db is empty
+        RM_DOWNLOAD_DB ( ch_rm_db.filter { _meta, db_url -> db_url != [] } )
 
         // Collect all h5 partitions (downloaded + any pre-staged) for famdb.py.
         // famdb.py uses '-i ./' so all files must be staged in the same work directory.


### PR DESCRIPTION
## Changes

- Fixed te subworkflow not working when using local database
- Replaced `oras` registry from seqera images for plain `https`
- Removed redundancy from containers and conda environments

## Comments

I had to change `oras` to plain `https` as singularity was not able to pull images with that registry. I don't know the reason, since it was working before, bot now it's fixed.

I still need to push a couple of changes.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
