### PR TITLE
Add missing decontamination nf-test snapshot

### DIFF
--- a/subworkflows/local/decontamination/tests/main.nf.test
+++ b/subworkflows/local/decontamination/tests/main.nf.test
@@ -36,8 +36,11 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
+                // fcs_gx_report's first line embeds a "run-date" timestamp (see the fcsgx/rungx
+                // module's own test, which skips the same line for the same reason), so only
+                // the deterministic column header + classification rows are snapshotted.
                 { assert snapshot(
-                    workflow.out.fcs_gx_report,
+                    workflow.out.fcs_gx_report.collect { meta, report -> [ meta, path(report).readLines()[1..-1] ] },
                     workflow.out.adaptor_report,
                     workflow.out.tiara_raw,
                     workflow.out.tiara_cleaned

--- a/subworkflows/local/decontamination/tests/main.nf.test.snap
+++ b/subworkflows/local/decontamination/tests/main.nf.test.snap
@@ -1,0 +1,130 @@
+{
+    "fcsgx_combo_test-fasta": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "taxid": "2697049"
+                    },
+                    "test.fcs_gx_report.txt:md5,c443e7f8104bfde632297cb5a8eb591e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "taxid": "2697049"
+                    },
+                    "test.fcs_adaptor_report.txt:md5,ba2ca11c57c95c1721aa7116fda3443d"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "taxid": "2697049"
+                    },
+                    "test.txt:md5,87d002ce5a02d01aa291991c643240e3"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "taxid": "2697049"
+                    },
+                    "test.txt:md5,87d002ce5a02d01aa291991c643240e3"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-10T19:41:17.213162",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
+    "fcsgx_combo_test-fasta-stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.fcs_gx_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.fcs_adaptor_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "adaptor_report": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.fcs_adaptor_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "fcs_gx_report": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.fcs_gx_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tiara_cleaned": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tiara_raw": [
+                    [
+                        {
+                            "id": "test",
+                            "taxid": "2697049"
+                        },
+                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-08-10T19:41:40.137359",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/subworkflows/local/decontamination/tests/main.nf.test.snap
+++ b/subworkflows/local/decontamination/tests/main.nf.test.snap
@@ -7,7 +7,11 @@
                         "id": "test",
                         "taxid": "2697049"
                     },
-                    "test.fcs_gx_report.txt:md5,c443e7f8104bfde632297cb5a8eb591e"
+                    [
+                        "#seq_id\tstart_pos\tend_pos\tseq_len\taction\tdiv\tagg_cont_cov\ttop_tax_name",
+                        "seq_00238\t1\t1000\t1000\tEXCLUDE\tprok:CFB group bacteria\t87\tBacteroides cutis",
+                        "seq_00289\t1\t1000\t1000\tEXCLUDE\tprok:CFB group bacteria\t88\tBacteroides gallinaceum"
+                    ]
                 ]
             ],
             [
@@ -38,7 +42,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-10T19:41:17.213162",
+        "timestamp": "2026-08-10T20:48:42.839023",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -121,7 +125,7 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-10T19:41:40.137359",
+        "timestamp": "2026-08-10T20:49:01.342436",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"


### PR DESCRIPTION
## Summary
- The `decontamination` subworkflow's real nf-test (`fcsgx_combo_test-fasta`) needs a ~4.2GB FCS-GX test-only database download, which was still in progress when 04a897d landed on `dev`. That left `subworkflows/local/decontamination/tests/main.nf.test.snap` missing, which fails CI in `--ci` mode ("snapshot with id 'fcsgx_combo_test-fasta' not found").
- This PR adds the missing snapshot, generated from a real passing run (FCS-adaptor → FCS-GX → Tiara, both raw and cleaned).

## Test plan
- [x] `nf-test test --profile=+docker subworkflows/local/decontamination/tests/main.nf.test` — both `fcsgx_combo_test-fasta` (real) and `fcsgx_combo_test-fasta-stub` pass locally
- [ ] CI green on this PR