### PR TITLE
Fix non-deterministic tree_data ordering in genome_only/genome_and_annotation

### DIFF
--- a/subworkflows/local/genome_and_annotation/main.nf
+++ b/subworkflows/local/genome_and_annotation/main.nf
@@ -249,7 +249,7 @@ workflow GENOME_AND_ANNOTATION {
 
     emit:
     orthofinder                = ch_orthofinder         // channel: [ val(meta), [folder] ]
-    tree_data                  = ch_tree_data.flatten().collect()
+    tree_data                  = ch_tree_data.flatten().collect().map { files -> files.toSorted { a, b -> a.name <=> b.name } } // sort for deterministic behaviour
     quast_results              = QUAST.out.results                   // channel: [ val(meta), [tsv] ]
     busco_short_summaries_geno = !params.skip_busco ? GAWK_GENO.out.output : channel.empty()
     busco_short_summaries_prot = !params.skip_busco ? GAWK_PROT.out.output : channel.empty()

--- a/subworkflows/local/genome_and_annotation/tests/main.nf.test
+++ b/subworkflows/local/genome_and_annotation/tests/main.nf.test
@@ -93,7 +93,21 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert snapshot(workflow.out).match() }
+                // tree_data is built by mix()-ing GENEOVERLAPS' and QUAST's outputs, which
+                // does not guarantee element order, so it's sorted before snapshotting
+                // instead of relying on raw workflow.out order.
+                { assert snapshot(
+                    workflow.out.orthofinder,
+                    workflow.out.tree_data.collect { files -> files.collect { file(it).name }.sort() },
+                    workflow.out.quast_results,
+                    workflow.out.busco_short_summaries_geno,
+                    workflow.out.busco_short_summaries_prot,
+                    workflow.out.quast_tsv,
+                    workflow.out.agat_stats,
+                    workflow.out.orthologous_chromosomes,
+                    workflow.out.buscos_per_seqs,
+                    workflow.out.versions
+                ).match() }
             )
         }
     }

--- a/subworkflows/local/genome_and_annotation/tests/main.nf.test.snap
+++ b/subworkflows/local/genome_and_annotation/tests/main.nf.test.snap
@@ -18,7 +18,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-10T19:16:55.862478",
+        "timestamp": "2026-08-10T21:14:08.471486",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -26,164 +26,85 @@
     },
     "sarscov2-single_genome_and_annotation-stub": {
         "content": [
-            {
-                "0": [
-                    
-                ],
-                "1": [
-                    [
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "test.counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            [
-                                "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            [
-                                "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-proteins-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "7": [
-                    
-                ],
-                "8": [
-                    
-                ],
-                "9": [
-                    
-                ],
-                "agat_stats": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "busco_short_summaries_geno": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "busco_short_summaries_prot": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-proteins-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "buscos_per_seqs": [
-                    
-                ],
-                "orthofinder": [
-                    
-                ],
-                "orthologous_chromosomes": [
-                    
-                ],
-                "quast_results": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        [
-                            [
-                                "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            [
-                                "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "quast_tsv": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "tree_data": [
-                    [
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "test.counts.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "versions": [
-                    
+            [
+                
+            ],
+            [
+                [
+                    "test.counts.tsv",
+                    "test.quast.tsv"
                 ]
-            }
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    [
+                        [
+                            "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
+                        "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        [
+                            "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
+                        "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test-bacteria_odb10-proteins-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.stats.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                
+            ]
         ],
-        "timestamp": "2026-08-10T19:17:09.738999",
+        "timestamp": "2026-08-10T21:14:25.452263",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"

--- a/subworkflows/local/genome_only/main.nf
+++ b/subworkflows/local/genome_only/main.nf
@@ -123,7 +123,7 @@ workflow GENOME_ONLY {
 
     emit:
     orthofinder             = !params.skip_busco ? ch_orthofinder : channel.empty()        // channel: [ val(meta), [folder] ]
-    tree_data               = !params.skip_busco ? ch_tree_data.flatten().collect() : channel.empty()
+    tree_data               = !params.skip_busco ? ch_tree_data.flatten().collect().map { files -> files.toSorted { a, b -> a.name <=> b.name } } : channel.empty() // sort for deterministic behaviour
     quast_results           = QUAST.out.results                   // channel: [ val(meta), [tsv] ]
     busco_short_summaries   = !params.skip_busco ? BUSCO_BUSCO.out.short_summaries_txt : channel.empty() // channel: [ val(meta), [txt] ]
     buscos_per_seqs         = !params.skip_busco ? GENOMEBUSCOIDEOGRAM.out.busco_mappings.collect { meta, table -> table}.map { tables -> tables.toSorted { a, b -> a.name <=> b.name } } : channel.empty() // channel: [ csv ]

--- a/subworkflows/local/genome_only/tests/main.nf.test
+++ b/subworkflows/local/genome_only/tests/main.nf.test
@@ -75,7 +75,18 @@ nextflow_workflow {
         then {
             assertAll(
                 { assert workflow.success },
-                { assert snapshot(workflow.out).match() }
+                // tree_data is built by mix()-ing QUAST's and GAWK's outputs, which does not
+                // guarantee element order, so it's sorted before snapshotting instead of
+                // relying on raw workflow.out order.
+                { assert snapshot(
+                    workflow.out.orthofinder,
+                    workflow.out.tree_data.collect { files -> files.collect { file(it).name }.sort() },
+                    workflow.out.quast_results,
+                    workflow.out.busco_short_summaries,
+                    workflow.out.buscos_per_seqs,
+                    workflow.out.busco_batch_summaries,
+                    workflow.out.quast_tsv
+                ).match() }
             )
         }
     }

--- a/subworkflows/local/genome_only/tests/main.nf.test.snap
+++ b/subworkflows/local/genome_only/tests/main.nf.test.snap
@@ -1,126 +1,66 @@
 {
     "bacteroides_fragilis-single_genome-stub": {
         "content": [
-            {
-                "0": [
-                    
-                ],
-                "1": [
+            [
+                
+            ],
+            [
+                [
+                    "test-bacteria_odb10-genome-busco.batch_summary_modified.txt",
+                    "test.quast.tsv"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
                     [
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
                         [
-                            [
-                                "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            [
-                                "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    
-                ],
-                "5": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "6": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "busco_batch_summaries": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "busco_short_summaries": [
-                    
-                ],
-                "buscos_per_seqs": [
-                    
-                ],
-                "orthofinder": [
-                    
-                ],
-                "quast_results": [
-                    [
-                        {
-                            "id": "test"
-                        },
+                            "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                            "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
+                        "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
                         [
-                            [
-                                "GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "Nx_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "cumulative_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                                "genome_GC_content_plot.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "icarus.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            [
-                                "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
-                            ],
-                            "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
-                            "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                        ]
-                    ]
-                ],
-                "quast_tsv": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "tree_data": [
-                    [
-                        "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
-                        "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                            "contig_size_viewer.html:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        ],
+                        "quast.log:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.html:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.pdf:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.tsv:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "report.txt:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "transposed_report.tex:md5,d41d8cd98f00b204e9800998ecf8427e",
+                        "transposed_report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ]
-            }
+            ],
+            [
+                
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test-bacteria_odb10-genome-busco.batch_summary_modified.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.quast.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ]
         ],
-        "timestamp": "2026-08-10T19:13:49.8403",
+        "timestamp": "2026-08-10T21:13:03.369419",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"
@@ -156,7 +96,7 @@
                 ]
             ]
         ],
-        "timestamp": "2026-08-10T19:13:40.719035",
+        "timestamp": "2026-08-10T21:12:52.933902",
         "meta": {
             "nf-test": "0.9.5",
             "nextflow": "25.10.4"


### PR DESCRIPTION
## Summary
- `genome_and_annotation` and `genome_only` both build `tree_data` by `mix()`-ing outputs from independent processes (QUAST + GENEOVERLAPS, and QUAST + GAWK respectively). `mix()` does not guarantee a stable element order, so the resulting file list could come out in different orders between runs/environments — same content, different order, different snapshot hash. This is what flaked CI on the subworkflow test suite (`GAWK_PROT` stub test diff showing `test.quast.tsv`/`test.counts.tsv` swapped).
- Fixes both at the source using the same `toSorted { a, b -> a.name <=> b.name }` pattern already used for `buscos_per_seqs` in both files, plus a defensive sort in the stub tests' snapshot assertions.

## Test plan
- [x] `nf-test test --profile=+docker subworkflows/local/genome_and_annotation/tests/main.nf.test subworkflows/local/genome_only/tests/main.nf.test` — 4/4 passing locally
- [ ] CI green on this PR