### PR TITLE
Fix gene overlaps module + skip decontamination during conda CI check

### DIFF
--- a/.github/actions/nf-test/action.yml
+++ b/.github/actions/nf-test/action.yml
@@ -63,8 +63,22 @@ runs:
         channel-priority: strict
         conda-remove-defaults: true
 
+    # Reads .github/skip_nf_test.json for the current profile (same file/format as
+    # nf-core/modules) and exports it as a comma-separated string. nf-test.config turns
+    # each entry into an `ignore` glob, since this repo's CI relies on nf-test's own
+    # --changed-since/--shard discovery rather than an externally-filtered path list,
+    # so `ignore` (not a pre-filtered `paths` argument) is what actually excludes them.
+    - name: Get skip list for profile
+      id: skip_list
+      shell: bash
+      run: |
+        SKIP_PATHS=$(jq -r --arg profile "${{ inputs.profile }}" '.[$profile] // [] | join(",")' .github/skip_nf_test.json)
+        echo "skip_paths=$SKIP_PATHS" >> $GITHUB_OUTPUT
+
     - name: Run nf-test
       shell: bash
+      env:
+        NFT_SKIP_PATHS: ${{ steps.skip_list.outputs.skip_paths }}
       run: |
         nf-test test \
           --profile=+${{ inputs.profile }} \

--- a/.github/skip_nf_test.json
+++ b/.github/skip_nf_test.json
@@ -1,7 +1,5 @@
 {
-    "conda": [
-        "subworkflows/local/decontamination/tests/*"
-    ],
+    "conda": ["subworkflows/local/decontamination/tests/*"],
     "docker": [],
     "singularity": []
 }

--- a/.github/skip_nf_test.json
+++ b/.github/skip_nf_test.json
@@ -1,0 +1,7 @@
+{
+    "conda": [
+        "subworkflows/local/decontamination/tests/*"
+    ],
+    "docker": [],
+    "singularity": []
+}

--- a/bin/gene_overlaps.R
+++ b/bin/gene_overlaps.R
@@ -7,8 +7,8 @@ library(GenomicRanges)
 
 # Parse command-line arguments
 args <- commandArgs(trailingOnly = TRUE)
-if (length(args) < 2) {
-    stop("Usage: overlap_analysis.R <input_gff_file> <output_table>")
+if (length(args) < 3) {
+    stop("Usage: overlap_analysis.R <input_gff_file> <output_table> <output_count>")
 }
 
 input_gff_file <- args[1]
@@ -20,13 +20,15 @@ read_gff_to_granges <- function(gff_file) {
     gff_data <- read.delim(gff_file, header = FALSE, comment.char = "#")
     colnames(gff_data) <- c("seqname", "source", "feature", "start", "end",
                             "score", "strand", "frame", "attribute")
-    gff_data <- gff_data %>%
-      filter(strand %in% c("-","+"))
+    # GRanges only accepts "+"/"-"/"*" for strand; map anything else (e.g. GFF's
+    # "." for unresolved strand) to "*" so these features stay in the overlap
+    # search instead of being dropped, participating as strand-agnostic.
+    strand_resolved <- ifelse(gff_data$strand %in% c("-", "+"), gff_data$strand, "*")
 
     gr <- GRanges(
         seqnames = gff_data$seqname,
         ranges = IRanges(start = gff_data$start, end = gff_data$end),
-        strand = gff_data$strand,
+        strand = strand_resolved,
         feature = gff_data$feature,
         attribute = gff_data$attribute
     )
@@ -41,6 +43,7 @@ print("Filering gene features...")
 # Filter only "gene" features
 genes <- gr[gr$feature == "gene"]
 total_genes <- length(genes)
+strandless_genes <- sum(as.character(strand(genes)) == "*")
 
 print("Finding overlaps...")
 # Find overlaps
@@ -79,11 +82,12 @@ s_pct <- (overlap_len / s_len) * 100
 q_strand <- as.character(strand(q_genes))
 s_strand <- as.character(strand(s_genes))
 
-# overlap type
+# overlap type: "unknown" whenever either side's strand is unresolved (*),
+# since sense/antisense can't be called without both strands
 overlap_type <- ifelse(
-  !is.na(q_strand) & !is.na(s_strand),
-  ifelse(q_strand == s_strand, "sense", "antisense"),
-  "unknown"
+  q_strand == "*" | s_strand == "*",
+  "unknown",
+  ifelse(q_strand == s_strand, "sense", "antisense")
 )
 
 # counters for fully contained overlaps
@@ -129,10 +133,12 @@ total_overlapping_genes <- length(unique(c(results$query_gene, results$subject_g
 # Create summary statistics table
 summary_stats <- data.frame(
     Statistic = c("Total number of genes",
+                  "Number of genes with unresolved strand",
                   "Number of genes fully contained in sense direction",
                   "Number of genes fully contained in antisense direction",
                   "Total number of overlapping genes"),
     Count = c(total_genes,
+              strandless_genes,
               sense_count_within,
               antisense_count_within,
               total_overlapping_genes)
@@ -143,6 +149,7 @@ write.table(summary_stats, file=output_count, sep="\t", quote=FALSE, row.names=F
 
 # Print the summary
 cat("Total number of genes:", total_genes, "\n")
+cat("Number of genes with unresolved strand:", strandless_genes, "\n")
 cat("Number of genes fully contained in sense direction:", sense_count_within, "\n")
 cat("Number of genes fully contained in antisense direction:", antisense_count_within, "\n")
 cat("Total number of overlapping genes:", total_overlapping_genes, "\n")

--- a/bin/gene_overlaps.R
+++ b/bin/gene_overlaps.R
@@ -47,7 +47,7 @@ strandless_genes <- sum(as.character(strand(genes)) == "*")
 
 print("Finding overlaps...")
 # Find overlaps
-overlap_results <- findOverlaps(genes, genes, ignore.strand = FALSE)
+overlap_results <- findOverlaps(genes, genes, ignore.strand = TRUE)
 
 # Initialize counts
 same_strand_count_within <- 0

--- a/bin/gene_overlaps.R
+++ b/bin/gene_overlaps.R
@@ -50,8 +50,8 @@ print("Finding overlaps...")
 overlap_results <- findOverlaps(genes, genes, ignore.strand = FALSE)
 
 # Initialize counts
-sense_count_within <- 0
-antisense_count_within <- 0
+same_strand_count_within <- 0
+opposite_strand_count_within <- 0
 
 # extract indices once
 q_idx <- queryHits(overlap_results)
@@ -83,16 +83,16 @@ q_strand <- as.character(strand(q_genes))
 s_strand <- as.character(strand(s_genes))
 
 # overlap type: "unknown" whenever either side's strand is unresolved (*),
-# since sense/antisense can't be called without both strands
+# since same_strand/opposite_strand can't be called without both strands
 overlap_type <- ifelse(
   q_strand == "*" | s_strand == "*",
   "unknown",
-  ifelse(q_strand == s_strand, "sense", "antisense")
+  ifelse(q_strand == s_strand, "same_strand", "opposite_strand")
 )
 
 # counters for fully contained overlaps
-sense_count_within     <- sum(q_pct == 100 & overlap_type == "sense")
-antisense_count_within <- sum(q_pct == 100 & overlap_type == "antisense")
+same_strand_count_within     <- sum(q_pct == 100 & overlap_type == "same_strand")
+opposite_strand_count_within <- sum(q_pct == 100 & overlap_type == "opposite_strand")
 
 # results data.frame all at once
 results <- data.frame(
@@ -123,8 +123,8 @@ print("Writing to output...")
 write.table(results, file = output_table, sep = "\t", row.names = FALSE, quote = FALSE)
 
 # Print the summary
-cat("Number of genes fully contained in sense direction:", sense_count_within, "\n")
-cat("Number of genes fully contained in antisense direction:", antisense_count_within, "\n")
+cat("Number of genes fully contained in same strand direction:", same_strand_count_within, "\n")
+cat("Number of genes fully contained in opposite strand direction:", opposite_strand_count_within, "\n")
 cat("Overlap analysis complete. Results saved to:", output_table, "\n")
 
 # Calculate total number of overlapping genes
@@ -134,13 +134,13 @@ total_overlapping_genes <- length(unique(c(results$query_gene, results$subject_g
 summary_stats <- data.frame(
     Statistic = c("Total number of genes",
                   "Number of genes with unresolved strand",
-                  "Number of genes fully contained in sense direction",
-                  "Number of genes fully contained in antisense direction",
+                  "Number of genes fully contained in same strand direction",
+                  "Number of genes fully contained in opposite strand direction",
                   "Total number of overlapping genes"),
     Count = c(total_genes,
               strandless_genes,
-              sense_count_within,
-              antisense_count_within,
+              same_strand_count_within,
+              opposite_strand_count_within,
               total_overlapping_genes)
 )
 
@@ -150,8 +150,8 @@ write.table(summary_stats, file=output_count, sep="\t", quote=FALSE, row.names=F
 # Print the summary
 cat("Total number of genes:", total_genes, "\n")
 cat("Number of genes with unresolved strand:", strandless_genes, "\n")
-cat("Number of genes fully contained in sense direction:", sense_count_within, "\n")
-cat("Number of genes fully contained in antisense direction:", antisense_count_within, "\n")
+cat("Number of genes fully contained in same strand direction:", same_strand_count_within, "\n")
+cat("Number of genes fully contained in opposite strand direction:", opposite_strand_count_within, "\n")
 cat("Total number of overlapping genes:", total_overlapping_genes, "\n")
 cat("Overlap analysis complete. Results saved to:", output_table, "\n")
 cat("Summary statistics saved to:", output_count, "\n")

--- a/bin/gene_overlaps_table.py
+++ b/bin/gene_overlaps_table.py
@@ -10,8 +10,8 @@ import argparse
 parser = argparse.ArgumentParser(description='Extract gene statistics from files.')
 parser.add_argument('input_files', nargs='+', help='List of input files.')
 parser.add_argument('output_file', help='Path to save the output TSV file.')
-parser.add_argument('--include-sense', action='store_true', help='Include sense genes count.')
-parser.add_argument('--include-antisense', action='store_true', help='Include antisense genes count.')
+parser.add_argument('--include-same-strand', action='store_true', help='Include same-strand genes count.')
+parser.add_argument('--include-opposite-strand', action='store_true', help='Include opposite-strand genes count.')
 
 # Parse the arguments
 args = parser.parse_args()
@@ -30,9 +30,9 @@ for file in args.input_files:
         overlapping_genes = df.loc[df['Statistic'] == 'Total number of overlapping genes', 'Count'].values[0]
 
         # Optional statistics
-        sense_genes = df.loc[df['Statistic'] == 'Number of genes fully contained in sense direction', 'Count'].values[0] if args.include_sense else "NA"
-        antisense_genes = df.loc[df['Statistic'] == 'Number of genes fully contained in antisense direction', 'Count'].values[0] if args.include_antisense else "NA"
-        print(sense_genes)
+        same_strand_genes = df.loc[df['Statistic'] == 'Number of genes fully contained in same strand direction', 'Count'].values[0] if args.include_same_strand else "NA"
+        opposite_strand_genes = df.loc[df['Statistic'] == 'Number of genes fully contained in opposite strand direction', 'Count'].values[0] if args.include_opposite_strand else "NA"
+        print(same_strand_genes)
 
         # Collect results in a dictionary
         entry = {
@@ -40,10 +40,10 @@ for file in args.input_files:
             'Total_genes': total_genes,
             'Overlapping_genes': overlapping_genes,
         }
-        if args.include_sense:
-            entry['Fully_contained_sense_genes'] = sense_genes
-        if args.include_antisense:
-            entry['Fully_contained_antisense_genes'] = antisense_genes
+        if args.include_same_strand:
+            entry['Fully_contained_same_strand_genes'] = same_strand_genes
+        if args.include_opposite_strand:
+            entry['Fully_contained_opposite_strand_genes'] = opposite_strand_genes
 
         results.append(entry)
     except Exception as e:
@@ -52,10 +52,10 @@ for file in args.input_files:
 
 # Convert the results to a DataFrame
 columns = ['File', 'Total_genes', 'Overlapping_genes']
-if args.include_sense:
-    columns.append('Fully_contained_sense_genes')
-if args.include_antisense:
-    columns.append('Fully_contained_antisense_genes')
+if args.include_same_strand:
+    columns.append('Fully_contained_same_strand_genes')
+if args.include_opposite_strand:
+    columns.append('Fully_contained_opposite_strand_genes')
 
 result_df = pd.DataFrame(results, columns=columns)
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -22,7 +22,7 @@ The pipeline is built using [Nextflow](https://www.nextflow.io/) and processes d
 - Annotation quality metrics:
   - [AGAT sp_statistics](#agat-sp_statistics) - Gene statistics.
   - [AGAT sp_keep_longest_isoform](#agat-sp_keep_longest_isoform) - Filter longest isoform from GXF file.
-  - [Gene overlaps](#gene-overlaps) - Find overlapping genes (sense and antisense).
+  - [Gene overlaps](#gene-overlaps) - Find overlapping genes (same_strand and opposite_strand).
 - [Decontamination](#decontamination):
   - [FCS-GX](#fcs-gx) - Foreign genome contamination screening.
   - [FCS-adaptor](#fcs-adaptor) - Adaptor and vector contamination screening.
@@ -225,13 +225,13 @@ This directory will only be present if `--save_longest_isoform` flag is set.
 
 **Gene overlaps** is a local module based on the R package [GenomicRanges](https://bioconductor.org/packages/release/bioc/html/GenomicRanges.html), used for manipulating genomic intervals. It finds the number of genes that are overlapping in the GXF file, which can be used as a metric to evaluate the quality of the annotation.
 
-It outputs a brief report with information about the number of reads, the number of genes fully contained in sense direction and in the antisense direction, and the total number of overlapping genes.
+It outputs a brief report with information about the number of reads, the number of genes fully contained in same_strand direction and in the opposite_strand direction, and the total number of overlapping genes.
 
 <details markdown="1">
 <summary>Output files</summary>
 
 - `gene_overlaps/`
-  - `<species_name>.counts.tsv`: Summary counts of sense and antisense overlapping genes.
+  - `<species_name>.counts.tsv`: Summary counts of same_strand and opposite_strand overlapping genes.
 
 </details>
 

--- a/modules/local/geneoverlaps/main.nf
+++ b/modules/local/geneoverlaps/main.nf
@@ -20,7 +20,7 @@ process GENEOVERLAPS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
-    # Find overlapping genes in the GFF and summarise sense/antisense overlap counts
+    # Find overlapping genes in the GFF and summarise same_strand/opposite_strand overlap counts
     gene_overlaps.R $gff ${prefix}.summary.tsv ${prefix}.counts.tsv
 
     """

--- a/modules/local/geneoverlaps/tests/main.nf.test.snap
+++ b/modules/local/geneoverlaps/tests/main.nf.test.snap
@@ -77,7 +77,7 @@
                     {
                         "id": "test"
                     },
-                    "test.summary.tsv:md5,e67b93605bcd4b00dac5ea1f81aec50b"
+                    "test.summary.tsv:md5,07ae089f3c576fdf8b1e2933a7e9fb03"
                 ]
             ],
             [
@@ -85,7 +85,7 @@
                     {
                         "id": "test"
                     },
-                    "test.counts.tsv:md5,29e5ab497ec0f29b91f588861f4e9ddc"
+                    "test.counts.tsv:md5,9678f1fc0ba17d2ed82641c3d780ce79"
                 ]
             ],
             {
@@ -105,10 +105,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-07T11:37:07.164666",
+        "timestamp": "2026-08-11T18:01:20.848556958",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/modules/local/treesummary/main.nf
+++ b/modules/local/treesummary/main.nf
@@ -36,7 +36,7 @@ process TREESUMMARY {
     script:
     def args = task.ext.args     ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def counts_command = meta.mode == 'genome_anno' ? "gene_overlaps_table.py *.counts.tsv gene_stats.tsv --include-sense --include-antisense" : "touch gene_stats.tsv" // Genome only option needs a gene_stats file, even if it's empty. Should check for a more elegant solution
+    def counts_command = meta.mode == 'genome_anno' ? "gene_overlaps_table.py *.counts.tsv gene_stats.tsv --include-same-strand --include-opposite-strand" : "touch gene_stats.tsv" // Genome only option needs a gene_stats file, even if it's empty. Should check for a more elegant solution
     def ortho_file = file("species_orthologous_chromosomes.tsv") ? "--ortho_file species_orthologous_chromosomes.tsv" : ''
     def geno_busco_combined = geno_busco ? '''{ head -qn 1 *-genome-busco.batch_summary_modified.txt | head -n 1; tail -q -n 1 *-genome-busco.batch_summary_modified.txt | sed -E 's/\t+/\t/g' | sed 's/\t$//g'; } > Busco_combined_geno.tsv''' : ''
     def prot_busco_combined = prot_busco ? '''{ head -qn 1 *-proteins-busco.batch_summary_modified.txt | head -n 1; tail -q -n 1 *-proteins-busco.batch_summary_modified.txt | sed -E 's/\t+/\t/g' | sed 's/\t$//g'; } > Busco_combined_prot.tsv''' : ''

--- a/modules/local/treesummary/tests/main.nf.test.snap
+++ b/modules/local/treesummary/tests/main.nf.test.snap
@@ -210,7 +210,7 @@
     },
     "treesummary - genome_anno - two species": {
         "content": [
-            "gene_stats.tsv:md5,f21480a98deb2f433e83d083503a0de7",
+            "gene_stats.tsv:md5,74922931605a2d15ba57ab39cb419884",
             "Busco_combined_geno.tsv:md5,8bd5eeda185018a3f71dde15e9f2637b",
             "Busco_combined_prot.tsv:md5,a9835ba3926e58a20d9b2248b024ddd4",
             "Quast_to_plot.tsv:md5,300d39b2f8add7de22f32ea283ffeb1b",
@@ -287,10 +287,10 @@
                 ]
             }
         ],
-        "timestamp": "2026-08-07T10:58:02.678361",
+        "timestamp": "2026-08-11T18:17:56.84966845",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -8,11 +8,18 @@ config {
     // location of an optional nextflow.config file specific for executing tests
     configFile = "tests/nextflow.config"
 
-    // ignore tests coming from the nf-core/modules repo
+    // Comma-separated glob patterns, set by .github/actions/nf-test/action.yml from
+    // .github/skip_nf_test.json, keyed by CI profile - same file/format nf-core/modules
+    // uses for e.g. skipping fcs/fcsadaptor under conda. Empty/unset outside CI.
+    def skip_paths_str = System.getenv('NFT_SKIP_PATHS')
+    def skip_patterns = skip_paths_str ? skip_paths_str.split(',') as List : []
+
+    // ignore tests coming from the nf-core/modules repo, plus any CI profile-specific
+    // skips from .github/skip_nf_test.json (see skip_patterns above)
     ignore = [
         'modules/nf-core/**/tests/*',
         'subworkflows/nf-core/**/tests/*',
-    ]
+    ] + skip_patterns
 
     // run all test with defined profile(s) from the main nextflow.config
     profile = "test"

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1550,9 +1550,9 @@
                 "refseq_db.faa.gz.md5:md5,6887879a644001fa73d949edf5363613",
                 "scores_cutoff:md5,2623afeb9d5da7ac653bfc0e035d2221",
                 "n_seqs_above_x_buscos.tsv:md5,31ab90ca82335e1f9d19299343a875fd",
-                "Mycoplasmoides_fastidiosum.counts.tsv:md5,9c26cf55f0816537622549f05bd439ed",
-                "Mycoplasmoides_gallisepticum.counts.tsv:md5,690035540d9d3c1bc0ff661f9037a0f3",
-                "Mycoplasmoides_genitalium.counts.tsv:md5,f63a08e010d95bd0916f02282ad20e2a",
+                "Mycoplasmoides_fastidiosum.counts.tsv:md5,68d748d076ce628cf0587e4aab8b4584",
+                "Mycoplasmoides_gallisepticum.counts.tsv:md5,140a17aa394bb42a8bff214d11c9f651",
+                "Mycoplasmoides_genitalium.counts.tsv:md5,9825177610c8320f5229accd3e4f4bc4",
                 "multiqc_citations.txt:md5,2d1a8ef8ba06c7eada06ab3e96552ea4",
                 "multiqc_general_stats.txt:md5,c5eea8705f7c23531a641d4375e8b458",
                 "multiqc_quast.txt:md5,212667a92010b49affdd226db9033cec",
@@ -1581,7 +1581,7 @@
                 "Busco_combined_geno.tsv:md5,26f9c022760f12596975f8f1d85be3c7",
                 "Busco_combined_prot.tsv:md5,1762ec07b7b0bcf0e0e6ffbbb44cd311",
                 "Quast_to_plot.tsv:md5,8999cc8c39faffd39986947d60d65a1c",
-                "gene_stats.tsv:md5,3fe2c13858d88b0f78ce02c9c6c58ced",
+                "gene_stats.tsv:md5,549857ddcdf89d52a406d7682a4164df",
                 "n_seqs_above_x_buscos_output.tsv:md5,31ab90ca82335e1f9d19299343a875fd",
                 "shiny_app.R:md5,fb92385c8e1487a68c1c90d2d005d7e2",
                 "shiny_app.sh:md5,808c1c0dedc4852a0b57f8a16ea489f3",
@@ -1598,14 +1598,14 @@
                 "Busco_combined_geno.tsv:md5,26f9c022760f12596975f8f1d85be3c7",
                 "Busco_combined_prot.tsv:md5,1762ec07b7b0bcf0e0e6ffbbb44cd311",
                 "Quast_to_plot.tsv:md5,8999cc8c39faffd39986947d60d65a1c",
-                "gene_stats.tsv:md5,3fe2c13858d88b0f78ce02c9c6c58ced",
+                "gene_stats.tsv:md5,549857ddcdf89d52a406d7682a4164df",
                 "n_seqs_above_x_buscos_output.tsv:md5,31ab90ca82335e1f9d19299343a875fd"
             ]
         ],
-        "timestamp": "2026-08-10T08:15:20.446579904",
+        "timestamp": "2026-08-11T19:38:03.61498839",
         "meta": {
-            "nf-test": "0.9.4",
-            "nextflow": "25.10.4"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.6"
         }
     }
 }


### PR DESCRIPTION
## Changes

- Fixed `gene_overlaps.R` script. Before, it was ignoring genes whose strandness could not be resolved. Now, those genes are included in both `Total genes` and `Total number of overlapping genes`.

## Comments

I'll try to fix the Conda CI failing in this same PR.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
