### PR TITLE
Fix stale v1.0.0dev in pipeline version snapshot

### DIFF
--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -91,7 +91,7 @@
                     "pigz": 2.8
                 },
                 "Workflow": {
-                    "nf-core/genomeqc": "v1.0.0dev"
+                    "nf-core/genomeqc": "v1.0.0"
                 }
             },
             [


### PR DESCRIPTION
## Summary

Follow-up to #263, which bumped `manifest.version` to `1.0.0` but merged before the corresponding snapshot update landed - `dev`'s \`docker | 7/7\` test is currently failing because \`tests/default.nf.test.snap\`'s embedded `Workflow.nf-core/genomeqc` version was still `v1.0.0dev`.

- Updates the one snapshot line to `v1.0.0`, matching the pipeline's actual reported version.

## Test plan

- [ ] CI: `docker | 7/7` passes on this PR