### PR TITLE
Added options for shiny container engine

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -33,7 +33,6 @@ params {
     config_profile_description = 'Minimal test dataset to check pipeline function'
 
     // Input data
-    //input  = params.pipelines_testdata_base_path + 'genomeqc/samplesheet/input_bacteria.csv'
     input  = params.pipelines_testdata_base_path + 'genomeqc/samplesheet/input_myco_tiny.csv'
 
     // BUSCO lienage

--- a/conf/test_decon.config
+++ b/conf/test_decon.config
@@ -5,7 +5,7 @@
     Defines input files and everything required to run a fast and simple pipeline test.
 
     Use as follows:
-        nextflow run ecoflow/genomeqc -profile test,<docker/singularity> --outdir <OUTDIR>
+        nextflow run nf-core/genomeqc -profile test,<docker/singularity> --outdir <OUTDIR>
 
 ----------------------------------------------------------------------------------------
 */

--- a/conf/test_nofastq.config
+++ b/conf/test_nofastq.config
@@ -25,8 +25,4 @@ params {
     // Input data
     input  = params.pipelines_testdata_base_path + 'genomeqc/samplesheet/input_bacteria_nofastq.csv'
 
-    // Don't try to skip merqury, but since you don't have reads, it shouldn't get run anyway
-    // (not necessary anymore, merqury doesn't run by default)
-    // merqury_skip = false
-
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -61,8 +61,9 @@
                 },
                 "container_engine": {
                     "type": "string",
-                    "description": "Container engine to run shiny app",
-                    "default": "docker"
+                    "description": "Container engine used to launch the interactive Shiny app. Only 'docker' and 'podman' are supported - Singularity/Apptainer does not work.",
+                    "default": "docker",
+                    "enum": ["docker", "podman"]
                 }
             }
         },


### PR DESCRIPTION
## Changes

- Added better description and options to `nextflow_schema.json` regarding shiny's `params.container_engine`. The only possible options are `[docker,podman]`.

## Comments

No further comments.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
