### PR TITLE
Hite error during validation

### DIFF
--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -173,7 +173,7 @@ def validateInputParameters() {
     def hite = params.te == 'hite'
     def profile_conda = workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1
     if (hite && profile_conda) {
-        error "The HiTE module does not support Conda. Please use Docker / Singularity / Podman instead or change the TE detection method to RepeatModeler/RepeatMasker"
+        error "The HiTE module does not support Conda. Please use Docker / Singularity / Podman instead or change the TE detection method to 'repeatmasker'"
     }
     // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
 }

--- a/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeqc_pipeline/main.nf
@@ -170,9 +170,12 @@ workflow PIPELINE_COMPLETION {
 // Check and validate pipeline parameters
 //
 def validateInputParameters() {
-    //genomeExistsError()
+    def hite = params.te == 'hite'
+    def profile_conda = workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1
+    if (hite && profile_conda) {
+        error "The HiTE module does not support Conda. Please use Docker / Singularity / Podman instead or change the TE detection method to RepeatModeler/RepeatMasker"
+    }
     // Add ways of validating input parameters, e.g. for groups in ncbigenomedownload
-
 }
 
 //


### PR DESCRIPTION
## Changes

- Added error message during validation of input parameters if both `params.te = 'hite'` and `-profile conda` are present.

## Comments

There's no conda package for hite.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
