### PR TITLE
Add reviewers to Credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ We thank the following people for their extensive assistance in the development 
 
 ### Review
 
-- [Vicbeg](https://github.com/Vicbeg)
+- [Victoria Begley](https://github.com/Vicbeg)
 - [awgymer](https://github.com/awgymer)
 - [Sébastien Guizard](https://github.com/sguizard) (The Roslin Institute)
 - [Matthias Hörtenhuber](https://github.com/mashehu) (SciLifeLab Data Centre)

--- a/README.md
+++ b/README.md
@@ -138,17 +138,25 @@ nf-core/genomeqc was originally written by [Chris Wyatt](https://github.com/chri
 
 We thank the following people for their extensive assistance in the development of this pipeline:
 
-- [Mahesh Binzer-Panchal](https://github.com/mahesh-panchal) ([National Bioinformatics Infrastructure Sweden](https://nbis.se/))
-- [Usman Rashid](https://github.com/GallVp) ([The New Zealand Institute for Plant and Food Research](https://www.plantandfood.com/en-nz/))
+### Code contributions
+
 - [Lauren Huet](https://github.com/LaurenHuet) ([Schmidt Ocean Institute](https://schmidtocean.org/))
 - [Stephen Turner](https://github.com/stephenturner/) ([Colossal Biosciences](https://colossal.com/))
 - [Felipe Perez Cobos](https://github.com/fperezcobos) ([Institute of Agrifood Research and Technology](https://www.irta.cat/en/))
 - [Simon Murray](https://github.com/SimonDMurray) ([Nextflow Ambassador](https://www.nextflow.io/our_ambassadors.html))
-- [Jacques Dainat](https://github.com/Juke34) (IRD)
-- [Famke Bäuerle](https://github.com/famosab) (University of Tuebingen)
-- [Matthias Hörtenhuber](https://github.com/mashehu) (SciLifeLab Data Centre)
-- [Sébastien Guizard](https://github.com/sguizard) (The Roslin Institute)
+
+### Guidance
+
+- [Usman Rashid](https://github.com/GallVp) ([The New Zealand Institute for Plant and Food Research](https://www.plantandfood.com/en-nz/))
+- [Mahesh Binzer-Panchal](https://github.com/mahesh-panchal) ([National Bioinformatics Infrastructure Sweden](https://nbis.se/))
+
+### Review
+
 - [Vicbeg](https://github.com/Vicbeg)
+- [Sébastien Guizard](https://github.com/sguizard) (The Roslin Institute)
+- [Matthias Hörtenhuber](https://github.com/mashehu) (SciLifeLab Data Centre)
+- [Famke Bäuerle](https://github.com/famosab) (University of Tuebingen)
+- [Jacques Dainat](https://github.com/Juke34) (IRD)
 
 ## Contributions and Support
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ We thank the following people for their extensive assistance in the development 
 - [Stephen Turner](https://github.com/stephenturner/) ([Colossal Biosciences](https://colossal.com/))
 - [Felipe Perez Cobos](https://github.com/fperezcobos) ([Institute of Agrifood Research and Technology](https://www.irta.cat/en/))
 - [Simon Murray](https://github.com/SimonDMurray) ([Nextflow Ambassador](https://www.nextflow.io/our_ambassadors.html))
+- [Jacques Dainat](https://github.com/Juke34) (IRD)
+- [Famke Bäuerle](https://github.com/famosab) (University of Tuebingen)
+- [Matthias Hörtenhuber](https://github.com/mashehu) (SciLifeLab Data Centre)
+- [Sébastien Guizard](https://github.com/sguizard) (The Roslin Institute)
+- [Vicbeg](https://github.com/Vicbeg)
 
 ## Contributions and Support
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ We thank the following people for their extensive assistance in the development 
 ### Review
 
 - [Vicbeg](https://github.com/Vicbeg)
+- [awgymer](https://github.com/awgymer)
 - [Sébastien Guizard](https://github.com/sguizard) (The Roslin Institute)
 - [Matthias Hörtenhuber](https://github.com/mashehu) (SciLifeLab Data Centre)
 - [Famke Bäuerle](https://github.com/famosab) (University of Tuebingen)


### PR DESCRIPTION
## Summary
- Adds PR reviewers (from the repo's review history) to the README `## Credits` list, alongside the existing contributors.
- Compiled by querying the repo's PR reviews and excluding the pipeline authors and `nf-core-bot`: Jacques Dainat, Famke Bäuerle, Matthias Hörtenhuber, Sébastien Guizard, Vicbeg.

**Marked as draft/WIP** - still deciding if anyone else should be added before this is ready for review.

## Test plan
- Docs-only change, no pipeline logic affected.