### PR TITLE
Removed echos and unused variables

### DIFF
--- a/modules/local/geneoverlaps/main.nf
+++ b/modules/local/geneoverlaps/main.nf
@@ -30,8 +30,6 @@ process GENEOVERLAPS {
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    echo $args
-
     touch ${prefix}.summary.tsv
     touch ${prefix}.counts.tsv
     """

--- a/modules/local/hite/main.nf
+++ b/modules/local/hite/main.nf
@@ -19,7 +19,7 @@ process HITE {
     script:
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        error "DEEPVARIANT module does not support Conda. Please use Docker / Singularity / Podman instead."
+        error "HITE module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
     def args   = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
@@ -65,6 +65,7 @@ process HITE {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+
     """
     mkdir -p ${prefix}_hite_results
     touch ${prefix}_hite_results/${prefix}.tbl

--- a/modules/local/ideogram/genome/main.nf
+++ b/modules/local/ideogram/genome/main.nf
@@ -20,6 +20,7 @@ process IDEOGRAM_GENOME {
     script:
     def args   = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+
     """
     # Plot a chromosome ideogram of genome-mode BUSCO gene locations
     grep -v "#" ${busco_full_table} | cut -f 2,3,4,5  | grep -v "Missing" > ${prefix}_busco_coordinates.txt
@@ -40,12 +41,9 @@ process IDEOGRAM_GENOME {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    echo $args
-
     touch ${prefix}.svg
     touch ${prefix}.png
     touch ${prefix}.csv

--- a/modules/local/ideogram/genomeannotation/main.nf
+++ b/modules/local/ideogram/genomeannotation/main.nf
@@ -41,12 +41,9 @@ process IDEOGRAM_GENOMEANNOTATION {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = "${meta.id}"
 
     """
-    echo $args
-
     touch ${prefix}.svg
     touch ${prefix}.png
     touch ${prefix}.csv

--- a/modules/local/mmseqs/easylinclust/main.nf
+++ b/modules/local/mmseqs/easylinclust/main.nf
@@ -20,6 +20,7 @@ process MMSEQS_EASYLINCLUST {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+
     """
     # Cluster sequences with MMseqs2 easy-linclust and keep one representative per cluster
     mmseqs \\
@@ -33,6 +34,7 @@ process MMSEQS_EASYLINCLUST {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
+
     """
     touch ${prefix}_rep_seq.fasta
     touch ${prefix}_all_seqs.fasta

--- a/modules/local/orthofinderv2/main.nf
+++ b/modules/local/orthofinderv2/main.nf
@@ -41,12 +41,9 @@ process ORTHOFINDERV2 {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    echo $args
-
     mkdir -p    $prefix/Comparative_Genomics_Statistics
     mkdir       $prefix/Gene_Duplication_Events
     mkdir       $prefix/Gene_Trees

--- a/modules/local/orthoseqcount/main.nf
+++ b/modules/local/orthoseqcount/main.nf
@@ -34,6 +34,7 @@ process ORTHOSEQCOUNT {
     """
 
     stub:
+
     """
     touch species_ortho_seq_count.tsv
     touch pairwise_ortho_seq_count.tsv

--- a/modules/local/repeatmasker/downloaddb/main.nf
+++ b/modules/local/repeatmasker/downloaddb/main.nf
@@ -37,6 +37,7 @@ process REPEATMASKER_DOWNLOADDB {
     stub:
     def filename   = db_url.tokenize('/')[-1]
     def out_gunzip = filename.replaceAll(/\.gz$/, '')
+
     """
     touch ${out_gunzip}
     """

--- a/modules/local/report/excel/main.nf
+++ b/modules/local/report/excel/main.nf
@@ -38,6 +38,7 @@ process REPORT_EXCEL {
     def tiara_arg      = tiara_reports       ? "--tiara_reports tiara/*"             : ""
     def busco_seqs_arg = busco_seqs_table    ? "--busco_seqs_table busco_seqs/*"     : ""
     def repeatmasker_arg = repeatmasker_tbls ? "--repeatmasker_tbls repeatmasker/*"  : ""
+
     """
     # Compile all per-tool QC tables into a single multi-sheet Excel workbook
     generate_excel.py \\
@@ -55,6 +56,7 @@ process REPORT_EXCEL {
     """
 
     stub:
+
     """
     touch genomeqc_tables.xlsx
     """

--- a/modules/local/report/html/main.nf
+++ b/modules/local/report/html/main.nf
@@ -39,6 +39,7 @@ process REPORT_HTML {
     def tiara_arg        = tiara_reports     ? "--tiara_reports tiara/*"            : ""
     def busco_seqs_arg   = busco_seqs_table  ? "--busco_seqs_table busco_seqs/*"    : ""
     def repeatmasker_arg = repeatmasker_tbls ? "--repeatmasker_tbls repeatmasker/*" : ""
+
     """
     # Build a self-contained HTML QC report from the available per-tool tables
     generate_report.py \\

--- a/modules/local/shinyapp/main.nf
+++ b/modules/local/shinyapp/main.nf
@@ -20,13 +20,12 @@ process SHINYAPP {
     tuple val("${task.process}"), val("cat"), eval("cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//'"), emit: versions_shiny, topic: versions
 
     script:
-    //def args   = task.ext.args ?: ''
-    def prefix                    = task.ext.prefix ?: "${meta.id}"
     def resolved_container_engine = container_engine ?: 'docker'
     // Fully qualify the registry: this is a plain `docker run`, so (unlike the
     // Nextflow-managed processes) it does not get the docker.registry='quay.io'
     // prefix and would otherwise resolve to Docker Hub, where the image is not published.
     def docker_url                = 'community.wave.seqera.io/library/python_pandas_r-base_bioconductor-ggtreeextra_pruned:5327fed29a6ac09f'
+
     """
     # Package the QC tables and tree into a launchable Shiny app container script
     mkdir app

--- a/modules/local/treesummary/main.nf
+++ b/modules/local/treesummary/main.nf
@@ -36,7 +36,6 @@ process TREESUMMARY {
 
     script:
     def args = task.ext.args     ?: ''
-    def prefix = task.ext.prefix ?: "${meta.id}"
     def counts_command = meta.mode == 'genome_anno' ? "gene_overlaps_table.py *.counts.tsv gene_stats.tsv --include-same-strand --include-opposite-strand" : "touch gene_stats.tsv" // Genome only option needs a gene_stats file, even if it's empty. Should check for a more elegant solution
     def ortho_file = file("species_ortho_seq_count.tsv") ? "--ortho_file species_ortho_seq_count.tsv" : ''
     def geno_busco_combined = geno_busco ? '''{ head -qn 1 *-genome-busco.batch_summary_modified.txt | head -n 1; tail -q -n 1 *-genome-busco.batch_summary_modified.txt | sed -E 's/\t+/\t/g' | sed 's/\t$//g'; } > Busco_combined_geno.tsv''' : ''
@@ -103,12 +102,9 @@ process TREESUMMARY {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
-    echo $args
-
     touch tree_plot.pdf
     touch tree_plot.svg
     touch tree.nw


### PR DESCRIPTION
## Changes

- Removed echo lines from stub block on local modules: `geneoverlaps`, `ideogram/genome`, `ideogram/genomeannotation`, `orthofinderv2`, `treesummary`.
- Removed unused variables from script block on local modules: `ideogram/genome`, `ideogram/genomeannotation`, `orthofinderv2`, `treesummary`, `shinyapp`.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
