### PR TITLE
Patch changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0.1 - [28 August 2026]
+## v1.0.1 - [12 Sepetember 2026]
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.0.1 - [28 August 2026]
+
+### `Fixed`
+
+- Fixed `ORTHO_SEQ_COUNT` reading `Orthogroups.tsv` via a manually-built path into OrthoFinder's output directory, which is unsafe on cloud storage. It now uses OrthoFinder's emited channel `orthogroups` as input.
+
+### `Dependencies`
+
+- Updated `ORTHOFINDER` module ([nf-core/modules#12899](https://github.com/nf-core/modules/pull/12899)).
+- Updated `QUAST` module ([nf-core/modules#12905](https://github.com/nf-core/modules/pull/12905)) to pin `python=3.11`. `-profile conda` was failing before.
+
 ## v1.0.0 - [28 August 2026]
 
 First release of nf-core/genomeqc, which compares the quality of multiple genomes and their annotations. The pipeline runs in two modes depending on the inputs provided: **Genome only** (FASTA files) and **Genome and Annotation** (FASTA plus GTF/GFF files).

--- a/docs/output.md
+++ b/docs/output.md
@@ -347,7 +347,7 @@ The pipeline supports both OrthoFinder v2 and v3 (selected via `--ortho_version`
 <details markdown="1">
 <summary>Output files</summary>
 
-- `orthofinder/v2/<prefix>/` or `orthofinder/v3/input/OrthoFinder/Results_<prefix>/` (depending on `--ortho_version`)
+- `orthofinder/v2/input/OrthoFinder/Results_<prefix>/` or `orthofinder/v3/input/OrthoFinder/Results_<prefix>/` (depending on `--ortho_version`)
   - `Orthogroups/`
     - Orthogroup assignments from MCL clustering (present in both v2 and v3).
   - `Species_Tree/`

--- a/docs/output.md
+++ b/docs/output.md
@@ -347,7 +347,7 @@ The pipeline supports both OrthoFinder v2 and v3 (selected via `--ortho_version`
 <details markdown="1">
 <summary>Output files</summary>
 
-- `orthofinder/v2/` or `orthofinder/v3/` (depending on `--ortho_version`)
+- `orthofinder/v2/<prefix>/` or `orthofinder/v3/input/OrthoFinder/Results_<prefix>/` (depending on `--ortho_version`)
   - `Orthogroups/`
     - Orthogroup assignments from MCL clustering (present in both v2 and v3).
   - `Species_Tree/`

--- a/modules/local/orthofinderv2/main.nf
+++ b/modules/local/orthofinderv2/main.nf
@@ -11,10 +11,10 @@ process ORTHOFINDERV2 {
     tuple val(meta), path(fastas, stageAs: 'input/')
 
     output:
-    tuple val(meta), path("$prefix")                                          , emit: orthofinder
-    path("$prefix/Phylogenetic_Hierarchical_Orthogroups/N0.tsv")              , emit: orthologues
-    path("$prefix/Orthogroups/Orthogroups.tsv")                               , emit: orthogroups
-    path("$prefix/Species_Tree/SpeciesTree_rooted_node_labels.txt")           , emit: speciestree
+    tuple val(meta), path("$results_dir")                                          , emit: orthofinder
+    path("$results_dir/Phylogenetic_Hierarchical_Orthogroups/N0.tsv")              , emit: orthologues
+    path("$results_dir/Orthogroups/Orthogroups.tsv")                               , emit: orthogroups
+    path("$results_dir/Species_Tree/SpeciesTree_rooted_node_labels.txt")           , emit: speciestree
     tuple val("${task.process}"), val('orthofinder'), eval("orthofinder -h | sed -n 's/.*version \\(.*\\) Copy.*/\\1/p'"), emit: versions_orthofinder, topic: versions
 
     when:
@@ -23,6 +23,7 @@ process ORTHOFINDERV2 {
     script:
     def args = task.ext.args ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
+    results_dir = "input/OrthoFinder/Results_${prefix}"
 
     """
     # Infer orthogroups and a species tree across the input proteomes with OrthoFinder2
@@ -35,35 +36,32 @@ process ORTHOFINDERV2 {
         -p temp_pickle \\
         -f input \\
         -n $prefix
-
-    mv \\
-    input/OrthoFinder/Results_$prefix \\
-    $prefix
     """
 
     stub:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
+    results_dir = "input/OrthoFinder/Results_${prefix}"
 
     """
     echo $args
 
-    mkdir -p    $prefix/Comparative_Genomics_Statistics
-    mkdir       $prefix/Gene_Duplication_Events
-    mkdir       $prefix/Gene_Trees
-    mkdir       $prefix/Orthogroup_Sequences
-    mkdir       $prefix/Orthogroups
-    mkdir       $prefix/Orthologues
-    mkdir       $prefix/Phylogenetic_Hierarchical_Orthogroups
-    mkdir       $prefix/Phylogenetically_Misplaced_Genes
-    mkdir       $prefix/Putative_Xenologs
-    mkdir       $prefix/Resolved_Gene_Trees
-    mkdir       $prefix/Single_Copy_Orthologue_Sequences
-    mkdir       $prefix/Species_Tree
-    mkdir       $prefix/WorkingDirectory
-    touch       $prefix/Log.txt
-    touch       $prefix/Orthogroups/Orthogroups.tsv
-    touch       $prefix/Species_Tree/SpeciesTree_rooted_node_labels.txt
-    touch       $prefix/Phylogenetic_Hierarchical_Orthogroups/N0.tsv
+    mkdir -p    $results_dir/Comparative_Genomics_Statistics
+    mkdir       $results_dir/Gene_Duplication_Events
+    mkdir       $results_dir/Gene_Trees
+    mkdir       $results_dir/Orthogroup_Sequences
+    mkdir       $results_dir/Orthogroups
+    mkdir       $results_dir/Orthologues
+    mkdir       $results_dir/Phylogenetic_Hierarchical_Orthogroups
+    mkdir       $results_dir/Phylogenetically_Misplaced_Genes
+    mkdir       $results_dir/Putative_Xenologs
+    mkdir       $results_dir/Resolved_Gene_Trees
+    mkdir       $results_dir/Single_Copy_Orthologue_Sequences
+    mkdir       $results_dir/Species_Tree
+    mkdir       $results_dir/WorkingDirectory
+    touch       $results_dir/Log.txt
+    touch       $results_dir/Orthogroups/Orthogroups.tsv
+    touch       $results_dir/Species_Tree/SpeciesTree_rooted_node_labels.txt
+    touch       $results_dir/Phylogenetic_Hierarchical_Orthogroups/N0.tsv
     """
 }

--- a/modules/local/orthofinderv2/meta.yml
+++ b/modules/local/orthofinderv2/meta.yml
@@ -36,22 +36,22 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. [ id:'test' ]
-      - $prefix:
+      - $results_dir:
           type: directory
-          description: Full OrthoFinder results directory (renamed from OrthoFinder's own Results_$prefix)
+          description: Full OrthoFinder results directory (OrthoFinder's own Results_$prefix, unrenamed)
   orthologues:
-    - $prefix/Phylogenetic_Hierarchical_Orthogroups/N0.tsv:
+    - $results_dir/Phylogenetic_Hierarchical_Orthogroups/N0.tsv:
         type: file
         description: Hierarchical orthogroups table (N0.tsv)
         pattern: "N0.tsv"
   orthogroups:
-    - $prefix/Orthogroups/Orthogroups.tsv:
+    - $results_dir/Orthogroups/Orthogroups.tsv:
         type: file
         description: Tab-separated file listing the genes belonging to each orthogroup,
           one row per orthogroup and one column per species.
         pattern: "Orthogroups.tsv"
   speciestree:
-    - $prefix/Species_Tree/SpeciesTree_rooted_node_labels.txt:
+    - $results_dir/Species_Tree/SpeciesTree_rooted_node_labels.txt:
         type: file
         description: Rooted species tree with internal node labels
         pattern: "SpeciesTree_rooted_node_labels.txt"


### PR DESCRIPTION
## Changes

- Added patch changelog.
- Removed `mv` line from orthofinder v2. Same issue as with the original orthofinder module, this line is a potential issue on cloud environments.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/genomeqc/tree/master/docs/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/genomeqc _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
